### PR TITLE
Add initial content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/Build/
+.DS_Store
+*_extdep/
+*.pyc
+__pycache__/
+*.bak
+BuildConfig.conf
+/Conf/
+settings.json

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -1,0 +1,85 @@
+## @file
+# Template file used to build supported packages.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) 2020 - 2021, ARM Limited. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: arch_list
+  displayName: Architectures (e.g. IA32, X64)
+  type: string
+  default: ''
+- name: build_file
+  displayName: Stuart Build File
+  type: string
+  default: ".pytool/CISettings.py"
+- name: do_ci_build
+  displayName: Perform Stuart CI Build
+  type: boolean
+  default: true
+- name: do_ci_setup
+  displayName: Perform Stuart CI Setup
+  type: boolean
+  default: true
+- name: do_non_ci_build
+  displayName: Perform non-CI Stuart Build
+  type: boolean
+  default: false
+- name: do_non_ci_setup
+  displayName: Perform non-CI Stuart Setup
+  type: boolean
+  default: false
+- name: extra_steps
+  displayName: Extra Steps
+  type: stepList
+  default:
+    - script: echo No extra steps provided
+- name: packages
+  displayName: Packages
+  type: string
+  default: ''
+- name: target_list
+  displayName: Targets (e.g. DEBUG, RELEASE)
+  type: string
+  default: ''
+- name: tool_chain_tag
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+- name: vm_image
+  displayName: Virtual Machine Image (e.g. windows-latest)
+  type: string
+  default: 'windows-latest'
+
+# Build step
+jobs:
+
+  - job: Build_${{ parameters.tool_chain_tag }}
+
+    #Use matrix to speed up the build process
+    strategy:
+      matrix:
+        TARGET_BUILD:
+          Build.Pkgs: ${{ parameters.packages }}
+          Build.Targets: ${{ parameters.target_list }}
+    workspace:
+      clean: all
+
+    pool:
+      vmImage: ${{ parameters.vm_image }}
+
+    steps:
+    - ${{ parameters.extra_steps }}
+    - template: ../Steps/PrGate.yml
+      parameters:
+        build_file: ${{ parameters.build_file }}
+        build_pkgs: $(Build.Pkgs)
+        build_targets: $(Build.Targets)
+        build_archs: ${{ parameters.arch_list }}
+        do_ci_build: ${{ parameters.do_ci_build }}
+        do_ci_setup: ${{ parameters.do_ci_setup }}
+        do_non_ci_build: ${{ parameters.do_non_ci_build }}
+        do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
+        tool_chain_tag: ${{ parameters.tool_chain_tag }}

--- a/Jobs/Python/RunDevTests.yml
+++ b/Jobs/Python/RunDevTests.yml
@@ -1,0 +1,69 @@
+## @file
+# Azure Pipelines job template to run Python developer tests.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: code_cov_enabled
+  displayName: Enable Code Coverage
+  type: boolean
+  default: false
+- name: custom_job_name
+  displayName: Custom Job name
+  type: string
+  default: ''
+- name: extra_steps
+  displayName: Extra Steps
+  type: stepList
+  default:
+    - script: echo No extra steps provided
+- name: pypi_auth_feed
+  displayName: PyPI Authorization Feed (Set For Release)
+  type: string
+  default: ''
+- name: root_package_folder
+  displayName: Root Package Folder
+  type: string
+  default: ''
+- name: vm_image
+  displayName: Virtual Machine Image (e.g. windows-latest)
+  type: string
+  default: 'windows-latest'
+
+jobs:
+
+- job: Build_and_Test_${{parameters.custom_job_name}}
+
+  workspace:
+    clean: all
+
+  pool:
+    vmImage: ${{ parameters.vm_image }}
+
+  steps:
+  - template: ../../Steps/SetNodeVersion.yml
+  - template: ../../Steps/SetupPythonPreReqs.yml
+    parameters:
+      pip_requirement_files: -r pip-requirements.txt -r py-requirements.txt
+  - ${{ parameters.extra_steps }}
+  - template: ../../Steps/Python/RunPytest.yml
+    parameters:
+      root_package_folder: ${{parameters.root_package_folder}}
+      code_cov_enabled: ${{parameters.code_cov_enabled}}
+
+  - template: ../../Steps/Python/RunFlake8Tests.yml
+
+  - template: ../../Steps/InstallSpellCheck.yml
+  - template: ../../Steps/RunSpellCheck.yml
+
+  - template: ../../Steps/InstallMarkdownLint.yml
+  - template: ../../Steps/RunMarkdownLint.yml
+
+  - task: PythonScript@0
+    inputs:
+      scriptSource: 'filePath'
+      scriptPath: 'BasicDevTests.py'
+    displayName: 'Check Basic File and Folder Tests'
+    condition: succeededOrFailed()

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,4 @@
+BSD-2-Clause-Patent License
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# Repository setup required :wave:
-      
-Please visit the website URL :point_right: for this repository to complete the setup of this repository and configure access controls.

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -1,0 +1,37 @@
+===================================================
+Project MU Developer Operations (DevOps) Repository
+===================================================
+
+This repository is part of Project Mu.  Please see Project Mu for details https://microsoft.github.io/mu
+
+This repository is used to manage files related to build, continuous integration (CI), and continuous deployment (CD)
+for other Project Mu repositories.
+
+Many of these files are generic YAML templates that can be combined together to compose a fully functional pipeline.
+
+Python based code leverages `edk2-pytools` to support cross platform building and execution.
+
+Continuous Integration (CI)
+===========================
+
+There are two broad categories of CI - Core CI and Platform CI.
+  - **Core CI** - Focused on building and testing all packages in Edk2 without an actual target platform.
+  - **Platform CI** - Focused on building a single target platform and confirming functionality on that platform.
+
+Conventions
+===========
+
+- Files extension should be `*.yml`. `*.yaml` is also supported but in edk2 we use those for our package
+  configuration.
+- Shared templates should be contributed to the `mu_devops` repository.
+- Platform CI files should be placed in a `<PlatformPkg>/.azurepipelines` folder in the platform repository.
+  - Top level CI files should be named `<HostOs><ToolChainTag>.yml`
+
+Links
+=====
+- `Basic Azure Landing Site <https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops>`_
+- `Pipeline jobs <https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml>`_
+- `Pipeline YAML scheme <https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema>`_
+- `Pipeline Expressions <https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops>`_
+- `PyTool Extensions <https://github.com/tianocore/edk2-pytool-extensions>`_
+- `PyTool Library <https://github.com/tianocore/edk2-pytool-library>`_

--- a/RepoDetails.md
+++ b/RepoDetails.md
@@ -1,0 +1,46 @@
+# Project MU Developer Operations (DevOps) Repository
+
+??? info "Git Details"
+    Repository Url: {{mu_devops.url}}
+    Branch:         {{mu_devops.branch}}
+    Commit:         [{{mu_devops.commit}}]({{mu_devops.commitlink}})
+    Commit Date:    {{mu_devops.date}}
+
+## Repository Philosophy
+
+Todo
+
+## Integration Instruction
+
+Todo
+
+## Code of Conduct
+
+This project has adopted the Microsoft Open Source Code of Conduct https://opensource.microsoft.com/codeofconduct/
+
+For more information see the Code of Conduct FAQ https://opensource.microsoft.com/codeofconduct/faq/
+or contact `opencode@microsoft.com <mailto:opencode@microsoft.com>`_. with any additional questions or comments.
+
+## Contributions
+
+Contributions are always welcome and encouraged!
+Please open any issues in the Project Mu GitHub tracker and read https://microsoft.github.io/mu/How/contributing/
+
+* [Code Requirements](https://microsoft.github.io/mu/CodeDevelopment/requirements/)
+* [Doc Requirements](https://microsoft.github.io/mu/DeveloperDocs/requirements/)
+
+## Issues
+
+Please open any issues in the Project Mu GitHub tracker. [More
+Details](https://microsoft.github.io/mu/How/contributing/)
+
+
+## Builds
+
+Please follow the steps in the Project Mu docs to build for CI and local
+testing. [More Details](https://microsoft.github.io/mu/CodeDevelopment/compile/)
+
+## Copyright
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/Steps/BuildBaseTools.yml
+++ b/Steps/BuildBaseTools.yml
@@ -1,0 +1,43 @@
+## @file
+# Azure Pipelines step template to build BaseTools.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: extra_parameters
+  displayName: Extra Edk2ToolsBuild.py Parameters
+  type: string
+  default: ''
+- name: tool_chain_tag
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+
+steps:
+- ${{ if contains(parameters.tool_chain_tag, 'GCC') }}:
+  - bash: sudo apt-get update
+    displayName: Update apt
+    condition: and(gt(variables.pkg_count, 0), succeeded())
+
+  - bash: sudo apt-get install gcc g++ make uuid-dev
+    displayName: Install required tools
+    condition: and(gt(variables.pkg_count, 0), succeeded())
+
+- task: CmdLine@1
+  displayName: Build Base Tools from source
+  inputs:
+    filename: python
+    arguments: BaseTools/Edk2ToolsBuild.py -t ${{ parameters.tool_chain_tag }} ${{ parameters.extra_parameters }}
+  condition: and(gt(variables.pkg_count, 0), succeeded())
+
+- task: CopyFiles@2
+  displayName: "Copy base tools build log"
+  inputs:
+    targetFolder: '$(Build.ArtifactStagingDirectory)'
+    SourceFolder: 'BaseTools/BaseToolsBuild'
+    contents: |
+      BASETOOLS_BUILD*.*
+    flattenFolders: true
+  condition: and(gt(variables.pkg_count, 0), succeededOrFailed())

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -1,0 +1,139 @@
+## @file
+# Azure Pipelines step template to build a platform.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: build_arch
+  displayName: Architectures (e.g. IA32, X64)
+  type: string
+  default: ''
+- name: build_base_tools
+  displayName: Build BaseTools
+  type: boolean
+  default: false
+- name: build_file
+  displayName: Build File
+  type: string
+  default: ''
+- name: build_flags
+  displayName: Build Flags
+  type: string
+  default: ''
+- name: build_pkg
+  displayName: Build Package
+  type: string
+  default: ''
+- name: build_target
+  displayName: Build Target (e.g. DEBUG, RELEASE)
+  type: string
+  default: ''
+- name: extra_install_step
+  displayName: Extra Install Steps
+  type: stepList
+  default: []
+- name: run_flags
+  displayName: Run Flags
+  type: string
+  default: ''
+- name: tool_chain_tag
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+
+steps:
+
+- checkout: self
+  clean: true
+  fetchDepth: 1
+
+- template: SetupPythonPreReqs.yml
+
+# Set default
+- bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
+
+# trim the package list if this is a PR
+- task: CmdLine@1
+  displayName: Check if ${{ parameters.build_pkg }} Needs Testing
+  inputs:
+    filename: stuart_pr_eval
+    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
+ # Setup repo
+- task: CmdLine@1
+  displayName: Setup
+  inputs:
+    filename: stuart_setup
+    arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+  condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# Stuart Update
+- task: CmdLine@1
+  displayName: Update
+  inputs:
+    filename: stuart_update
+    arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+  condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# build basetools
+#   do this after setup and update so that code base dependencies
+#   are all resolved.
+- ${{ if eq(parameters.build_base_tools, true) }}:
+  - template: BuildBaseTools.yml
+    parameters:
+      tool_chain_tag: ${{ parameters.tool_chain_tag }}
+
+# Potential Extra steps
+- ${{ parameters.extra_install_step }}
+
+# Build
+- task: CmdLine@1
+  displayName: Build
+  inputs:
+    filename: stuart_build
+    arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+  condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# Run
+- task: CmdLine@1
+  displayName: Run to Shell
+  inputs:
+    filename: stuart_build
+    arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
+  condition: and(and(gt(variables.pkg_count, 0), succeeded()), eq(variables['Run'], true))
+  timeoutInMinutes: 1
+
+# Copy the build logs to the artifact staging directory
+- task: CopyFiles@2
+  displayName: Copy Build Logs
+  inputs:
+    targetFolder: "$(Build.ArtifactStagingDirectory)"
+    SourceFolder: "Build"
+    contents: |
+      BUILDLOG_*.txt
+      BUILDLOG_*.md
+      CI_*.txt
+      CI_*.md
+      CISETUP.txt
+      SETUPLOG.txt
+      UPDATE_LOG.txt
+      PREVALLOG.txt
+      TestSuites.xml
+      **/BUILD_TOOLS_REPORT.html
+      **/OVERRIDELOG.TXT
+      BASETOOLS_BUILD*.*
+      **/FD_REPORT.HTML
+    flattenFolders: true
+  condition: succeededOrFailed()
+
+# Publish build artifacts to Azure Artifacts/TFS or a file share
+- task: PublishBuildArtifacts@1
+  continueOnError: true
+  displayName: Publish Build Logs
+  inputs:
+    pathtoPublish: "$(Build.ArtifactStagingDirectory)"
+    artifactName: "Build Logs $(System.JobName)"
+  condition: succeededOrFailed()

--- a/Steps/FetchGitHubFile.yml
+++ b/Steps/FetchGitHubFile.yml
@@ -1,0 +1,39 @@
+## @file
+# Azure Pipelines step template to fetch a single file
+# from the top of a given branch in a public GitHub repo.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: dest_file_path
+  displayName: Destination File Path
+  type: string
+  default: ''
+- name: display_name
+  displayName: Display Name
+  type: string
+  default: Fetch GitHub File
+- name: github_repo
+  displayName: GitHub Repo
+  type: string
+  default: ''
+- name: source_branch
+  displayName: Source Branch
+  type: string
+  default: ''
+- name: source_file_path
+  displayName: Source File Path
+  type: string
+  default: ''
+
+steps:
+
+  - powershell:
+      $branch_url = '${{ parameters.source_branch }}'.replace('refs/heads/', '');
+      $fetch_source = 'https://raw.githubusercontent.com/${{ parameters.github_repo }}/'+$branch_url+'/${{ parameters.source_file_path }}';
+      Write-Host $fetch_source;
+      (New-Object System.Net.WebClient).DownloadFile($fetch_source, '${{ parameters.dest_file_path }}');
+    displayName: ${{ parameters.display_name }}
+    condition: succeeded()

--- a/Steps/InstallMarkdownLint.yml
+++ b/Steps/InstallMarkdownLint.yml
@@ -1,0 +1,12 @@
+## @file
+# Azure Pipelines step template to install markdownlint.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- script: npm install -g markdownlint-cli@0.31.0
+  displayName: Install Markdown Linter
+  condition: succeeded()

--- a/Steps/InstallSpellCheck.yml
+++ b/Steps/InstallSpellCheck.yml
@@ -1,0 +1,12 @@
+## @file
+# Azure Pipelines step template to install spell check (cspell).
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- script: npm install -g cspell@5.20.0
+  displayName: Install cspell npm
+  condition: succeeded()

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -1,0 +1,172 @@
+## @file
+# Azure Pipelines step template to build for a pull request.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: build_archs
+  displayName: Architectures (e.g. IA32, X64)
+  type: string
+  default: ''
+- name: build_file
+  displayName: Stuart Build File
+  type: string
+  default: ".pytool/CISettings.py"
+- name: build_pkgs
+  displayName: Packages
+  type: string
+  default: ''
+- name: build_targets
+  displayName: Targets (e.g. DEBUG, RELEASE)
+  type: string
+  default: ''
+- name: do_ci_build
+  displayName: Perform Stuart CI Build
+  type: boolean
+  default: true
+- name: do_ci_setup
+  displayName: Perform Stuart CI Setup
+  type: boolean
+  default: true
+- name: do_non_ci_build
+  displayName: Perform non-CI Stuart Build
+  type: boolean
+  default: false
+- name: do_non_ci_setup
+  displayName: Perform non-CI Stuart Setup
+  type: boolean
+  default: false
+- name: tool_chain_tag
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+
+steps:
+- checkout: self
+  clean: true
+  # Note: Depth cannot be limited if PR Eval is used
+
+- template: SetupPythonPreReqs.yml
+
+# Set Default Package Info
+- bash: |
+    echo "##vso[task.setvariable variable=pkgs_to_build]${{ parameters.build_pkgs }}"
+    echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
+
+# $System.PullRequest.targetBranch looks like "dev/whatever" on GitHub,
+# but looks like "refs/heads/dev/whatever" on DevOps. The DevOps version
+# can't be used for comparison for the PR Eval.
+- powershell:
+    $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
+    Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
+  displayName: Apply Branch Name Workaround
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
+# Trim the package list if this is a PR
+- task: CmdLine@1
+  displayName: Check if ${{ parameters.build_pkgs }} Needs Testing
+  inputs:
+    filename: stuart_pr_eval
+    # Workaround an azure pipelines bug.
+    arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target $(pr_compare_branch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
+- template: InstallSpellCheck.yml
+
+- template: InstallMarkdownLint.yml
+
+# Build repo
+- ${{ if eq(parameters.do_ci_setup, true) }}:
+  - task: CmdLine@1
+    displayName: CI Setup ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    inputs:
+      filename: stuart_ci_setup
+      arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) --force-git -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    condition: succeeded()
+
+- ${{ if eq(parameters.do_non_ci_setup, true) }}:
+  - task: CmdLine@1
+    displayName: Setup ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    inputs:
+      filename: stuart_setup
+      arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    condition: succeeded()
+
+- task: CmdLine@1
+  displayName: Update ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+  inputs:
+    filename: stuart_update
+    arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+  condition: succeeded()
+
+- ${{ if eq(parameters.do_non_ci_build, true) }}:
+  - task: CmdLine@1
+    displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    inputs:
+      filename: stuart_build
+      arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    condition: succeeded()
+
+- ${{ if eq(parameters.do_ci_build, true) }}:
+  - task: CmdLine@1
+    displayName: CI Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    inputs:
+      filename: stuart_ci_build
+      arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    condition: succeeded()
+
+# Publish Test Results to Azure Pipelines/TFS
+- task: PublishTestResults@2
+  displayName: Publish junit Test Results
+  continueOnError: true
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'JUnit'                  # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFiles: 'Build/TestSuites.xml'
+    mergeTestResults: true                      # Optional
+    testRunTitle: $(System.JobName)             # Optional
+    publishRunAttachments: true                 # Optional
+
+# Publish Test Results to Azure Pipelines/TFS
+- task: PublishTestResults@2
+  displayName: Publish Host-Based Unit Test Results for $(System.JobName)
+  continueOnError: true
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'JUnit'                  # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFiles: 'Build/**/*.result.xml'
+    mergeTestResults: false                     # Optional
+    testRunTitle: ${{ parameters.build_pkgs }}  # Optional
+    publishRunAttachments: true                 # Optional
+
+# Copy the build logs to the artifact staging directory
+- task: CopyFiles@2
+  displayName: Copy Build Logs
+  inputs:
+    targetFolder: '$(Build.ArtifactStagingDirectory)'
+    SourceFolder: 'Build'
+    contents: |
+      BUILDLOG_*.txt
+      BUILDLOG_*.md
+      CI_*.txt
+      CI_*.md
+      CISETUP.txt
+      SETUPLOG.txt
+      UPDATE_LOG.txt
+      PREVALLOG.txt
+      TestSuites.xml
+      **/BUILD_TOOLS_REPORT.html
+      **/OVERRIDELOG.TXT
+    flattenFolders: true
+  condition: succeededOrFailed()
+
+# Publish build artifacts to Azure Artifacts/TFS or a file share
+- task: PublishBuildArtifacts@1
+  continueOnError: true
+  displayName: Publish Build Logs
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: 'Build Logs $(System.JobName)'
+  condition: succeededOrFailed()

--- a/Steps/Python/RunFlake8Tests.yml
+++ b/Steps/Python/RunFlake8Tests.yml
@@ -1,0 +1,24 @@
+## @file
+# Azure Pipelines step template to run flake8 and publish
+# an error log if any errors occur.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+- script: flake8 .
+  displayName: 'Run flake8'
+  condition: succeededOrFailed()
+
+# Only capture and archive the lint log on failures.
+- script: flake8 . > flake8.err.log
+  displayName: 'Capture flake8 Failures'
+  condition: Failed()
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: 'flake8.err.log'
+    artifactName: 'Flake8 Error Log File'
+  continueOnError: true
+  condition: Failed()

--- a/Steps/Python/RunPytest.yml
+++ b/Steps/Python/RunPytest.yml
@@ -1,0 +1,53 @@
+## @file
+# Azure Pipelines step template to run pytest.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: code_cov_enabled
+  displayName: Enable Code Coverage
+  type: boolean
+  default: false
+- name: root_package_folder
+  displayName: Root Package Folder
+  type: string
+  default: ''
+
+steps:
+- script: pytest -v --junitxml=test.junit.xml --html=pytest_report.html --self-contained-html --cov=${{ parameters.root_package_folder }} --cov-report html:cov_html --cov-report xml:cov.xml --cov-config .coveragerc
+  displayName: 'Run pytest Unit Tests'
+
+# Publish Test Results to Azure Pipelines/TFS
+- task: PublishTestResults@2
+  displayName: 'Publish junit Test Results'
+  continueOnError: true
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFiles: 'test.junit.xml'
+    mergeTestResults: true # Optional
+    publishRunAttachments: true # Optional
+
+# Publish build artifacts to Azure Pipelines
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: 'pytest_report.html'
+    artifactName: 'unit test report'
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- script: |
+    curl -s https://codecov.io/bash | bash -s -- -C $(Build.SourceVersion) -F $(Agent.OS)
+  displayName: 'Upload to codecov.io'
+  continueOnError: true
+  condition: ${{parameters.code_cov_enabled}}
+
+# Publish Cobertura code coverage results
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'cobertura' # Options: cobertura, jaCoCo
+    summaryFileLocation: $(System.DefaultWorkingDirectory)/cov.xml
+    reportDirectory: $(System.DefaultWorkingDirectory)/cov_html
+  condition: succeededOrFailed()

--- a/Steps/RunMarkdownLint.yml
+++ b/Steps/RunMarkdownLint.yml
@@ -1,0 +1,16 @@
+## @file
+# Azure Pipelines step to lint markdown files
+# in the repository.
+#
+# markdownlint should be installed on the system
+# prior to invoking this template.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- script: markdownlint "**/*.md"
+  displayName: Lint MD Files
+  condition: succeeded()

--- a/Steps/RunPatchCheck.yml
+++ b/Steps/RunPatchCheck.yml
@@ -1,0 +1,33 @@
+## @file
+# Azure Pipelines step to evaluate the patch series in a PR by
+# running BaseTools/Scripts/PatchCheck.py.
+#
+# NOTE: This example monitors pull requests against the edk2-ci branch. Most
+# environments would replace 'edk2-ci' with 'master'.
+#
+# Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# https://github.com/tianocore
+#
+##
+
+trigger: none
+
+pr:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- checkout: self
+  clean: true
+
+- template: Steps/SetupPythonPreReqs.yml
+- script: |
+    git fetch origin $(System.PullRequest.TargetBranch):$(System.PullRequest.TargetBranch)
+    python BaseTools/Scripts/PatchCheck.py $(System.PullRequest.TargetBranch)..$(System.PullRequest.SourceCommitId)
+  displayName: Use PatchCheck.py to Verify Patch Series in Pull Request
+  condition: succeeded()

--- a/Steps/RunSpellCheck.yml
+++ b/Steps/RunSpellCheck.yml
@@ -1,0 +1,22 @@
+## @file
+# Azure Pipelines step to run spell check against
+# a set of files.
+#
+# cspell should be installed on the system
+# prior to invoking this template.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: spell_check_parameters
+  displayName: Spell Check (cspell) Parameters
+  type: string
+  default: "-c .cspell.json **/*.py"
+
+steps:
+
+- script: cspell ${{ parameters.spell_check_parameters }}
+  displayName: Run Spell Check Test
+  condition: succeeded()

--- a/Steps/SetNodeVersion.yml
+++ b/Steps/SetNodeVersion.yml
@@ -1,0 +1,13 @@
+## @file
+# Azure Pipelines step template to set the Node version.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.x'
+  condition: succeeded()

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -1,0 +1,24 @@
+## @file
+# Azure Pipelines step to setup Python pre-requisites.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: pip_requirement_files
+  displayName: Pip Requirement Files
+  type: string
+  default: -r pip-requirements.txt
+
+steps:
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: ">=3.10.6"
+    architecture: x64
+
+- script: pip install ${{ parameters.pip_requirement_files }} --upgrade
+  displayName: Install and Upgrade pip Modules
+  condition: succeeded()
+


### PR DESCRIPTION
This adds starting content for the Mu Developer Operations (DevOps)
repo.

This repo (at least at this time) is primarily composed of Azure
Pipelines YAML files used as common resources between many Project
Mu repositories.

Repos are intended to bind against a source repository at pipeline
build time to expose the templates used for the build.
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema#define-a-repositories-resource

Each "leaf" YAML file (the YAML file used in the actual pipeline) is
expected to define a repository resource onto this repo and include
the appropriate top-level template file.

Typically, this is:
  - Jobs/PrGate.yml
  - Steps/BuildPlatform.yml

Each template provides parameter customization for common config
points of steps implemented in the template.

This change is considered an initial refactoring and convergence of
build functionality with the goal to replicate pipeline behavior
using these templates in this converged repo. It will be iterated
and impoved upon in future changes.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>