### PR TITLE
PrGate.yml: Add do_pr_eval template parameter

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -31,6 +31,10 @@ parameters:
   displayName: Perform non-CI Stuart Setup
   type: boolean
   default: false
+- name: do_pr_eval
+  displayName: Perform Stuart PR Evaluation
+  type: boolean
+  default: true
 - name: extra_steps
   displayName: Extra Steps
   type: stepList

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -38,6 +38,10 @@ parameters:
   displayName: Perform non-CI Stuart Setup
   type: boolean
   default: false
+- name: do_pr_eval
+  displayName: Perform Stuart PR Evaluation
+  type: boolean
+  default: true
 - name: tool_chain_tag
   displayName: Tool Chain (e.g. VS2022)
   type: string
@@ -65,13 +69,14 @@ steps:
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
 # Trim the package list if this is a PR
-- task: CmdLine@1
-  displayName: Check if ${{ parameters.build_pkgs }} Needs Testing
-  inputs:
-    filename: stuart_pr_eval
-    # Workaround an azure pipelines bug.
-    arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target $(pr_compare_branch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+- ${{ if eq(parameters.do_pr_eval, true) }}:
+  - task: CmdLine@1
+    displayName: Check if ${{ parameters.build_pkgs }} Needs Testing
+    inputs:
+      filename: stuart_pr_eval
+      # Workaround an azure pipelines bug.
+      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target $(pr_compare_branch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
+    condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - template: InstallSpellCheck.yml
 


### PR DESCRIPTION
Allow repos using the templates to opt out of PR evaluation.

The default is to perform PR eval for backward compatibility with
current users.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>