### PR TITLE
Jobs/PrGate.yml: Pass do_pr_eval value to step template

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -86,4 +86,5 @@ jobs:
         do_ci_setup: ${{ parameters.do_ci_setup }}
         do_non_ci_build: ${{ parameters.do_non_ci_build }}
         do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
+        do_pr_eval: ${{ parameters.do_pr_eval }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}


### PR DESCRIPTION
Passes the value given to the job template (from the platform YAML
file) to the Steps/PrGate.yml template file.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>