### PR TITLE
Add CodeQL reusable GitHub workflow

### DIFF
--- a/.github/workflows/CodeQl.yml
+++ b/.github/workflows/CodeQl.yml
@@ -1,0 +1,88 @@
+## @file
+# GitHub action CodeQL reusable workflow file.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: Mu DevOps CodeQL Workflow
+
+on:
+  workflow_call:
+    inputs:
+      # Note: The caller can set a command to an empty string to skip that command
+      setup_command:
+        description: 'Stuart Setup command to use'
+        default: ''
+        required: false
+        type: string
+      update_command:
+        description: 'Stuart Update command to use'
+        default: 'stuart_update -c .pytool/CISettings.py'
+        required: false
+        type: string
+      build_command:
+        description: 'Stuart Build command to use'
+        default: 'stuart_ci_build -c .pytool/CISettings.py'
+        required: false
+        type: string
+      python_version:
+        description: 'Python version to use in the workflow'
+        default: '3.x'
+        required: false
+        type: string
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Setup Python Version
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python_version }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    - name: 'Install/Upgrade pip Modules'
+      run: pip install -r pip-requirements.txt --upgrade
+
+    - name: 'Setup'
+      if: "${{ inputs.setup_command != '' }}"
+      run: ${{ inputs.setup_command }}
+
+    - name: 'Update'
+      if: "${{ inputs.update_command != '' }}"
+      run: ${{ inputs.update_command }}
+
+    - name: 'Build'
+      if: "${{ inputs.build_command != '' }}"
+      run: ${{ inputs.build_command }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Adds a new workflow YAML file that can be reused by repos that need
to run CodeQL.

The workflow accepts the following input strings:
  - setup_command - The (Stuart) setup command to run
  - update_command - The (Stuart) update command to run
  - build_command - The (Stuart) build command to run
  - python_version - The Python version to use

The command strings can be an empty string to skip that command.

The default Python version is currently '3.x'.

This reusable workflow encapsulates common CodeQL pre and post
build steps and centralizes default values for common configuration
points like the Python version to use for CodeQL workflows.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>