### PR TITLE
Add Project Mu status notebooks

### DIFF
--- a/Notebooks/MyPullRequests.github-issues
+++ b/Notebooks/MyPullRequests.github-issues
@@ -1,0 +1,82 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Project Mu GitHub Personal Dashboard\r\n\r\nThis notebook displays your issue & personal pull request status across [Project Mu](https://microsoft.github.io/mu/)\r\nrepos."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Pull Requests"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✶ All My Pull Requests"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open type:pr"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✅ Approved"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open type:pr review:approved"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "⌛ Pending Approval"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos author:@me is:open is:pr review:required"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "## Issues"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✶ All My Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos assignee:@me is:open"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🐛 My Open Bugs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos assignee:@me is:open label:bug"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✨ My Enhancements"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos assignee:@me is:open label:enhancement"
+  }
+]

--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -1,0 +1,52 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Project Mu GitHub PR Dashboard\r\n\r\nThis notebook displays [Project Mu](https://microsoft.github.io/mu/) pull request status."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 All Open PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 - 🤖 = Opened by Humans"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview -author:app/microsoft-github-policy-service"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "✅ All Approved PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open type:pr review:approved"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "🏁 All Completed PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// This needs to be bumped very occassionally (annually likely) to prevent\r\n// the maximum allowed number of results from being reached.\r\n$since=2022-01-01\r\n\r\n$repos is:closed type:pr sort:created-desc closed:>$since"
+  }
+]

--- a/Notebooks/ReadMe.md
+++ b/Notebooks/ReadMe.md
@@ -1,0 +1,26 @@
+# Project Mu VS Code Notebooks
+
+These notebooks summarize Project Mu information across all of the Project Mu repos.
+
+## How to Use
+
+1. Install [Visual Studio Code (VS Code)](https://code.visualstudio.com/)
+2. Install the `GitHub Issue Notebooks` VS Code extension
+   - Extension ID: ms-vscode.vscode-github-issue-notebooks
+   - [Marketplace link](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks)
+3. Open a notebook file (e.g. `PullRequests.github-issues`)
+4. Click `Run All` at the top of the  file to run all the queries
+
+## How to View Dashboard in Web Browser
+
+Since VS Code can run in your Web browser, you can treat this dashboard as a Web page rather than a file that you open
+locally.
+
+To view the file in the Web version of VS Code, simply open the file in GitHub and replace `github.com` with
+`github.dev` in the URL.
+
+- [Project Mu Pull Request Dashboard](https://github.dev/microsoft/mu_devops/blob/main/Notebooks/PullRequests.github-issues)
+- [Project Mu Personal Issue & Pull Request Dashboard](https://github.com/microsoft/mu_devops/blob/main/Notebooks/MyPullRequests.github-issues)
+
+Once opened, run the same steps in [How to Use](#how-to-use) to install the extension and view the file. You can then
+save the page to your bookmarks so you can easily load it in the future.


### PR DESCRIPTION
Adds github-issues notebooks that present a dashboard of Project Mu
status. These can be opened in VS Code using the "GitHub Issue
Notebooks" extension. By extension, they can also be opened using the
VS Code web interface to view in a Web browser.

For more information, see the Notebooks/ReadMe.md file.

Dashboard Examples:

## **Overall Dashboard**

![image](https://user-images.githubusercontent.com/21320094/188683682-ded9a7ed-cc3e-448d-915f-f7495863a1bd.png)
.   .   .
![image](https://user-images.githubusercontent.com/21320094/188683726-af5558f3-e309-45eb-9823-210632d915c8.png)

## **Personal Dashboard**
![image](https://user-images.githubusercontent.com/21320094/188683804-0429953d-6c76-48f0-a9b4-ac5cfc39f842.png)
.   .   .
![image](https://user-images.githubusercontent.com/21320094/188683841-7badd2fe-3876-4460-a2f7-63c3db1999f6.png)


Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>