### PR TITLE
ApplyAdoBranchNameWorkaround.yml: Add file

### DIFF
--- a/Steps/ApplyAdoBranchNameWorkaround.yml
+++ b/Steps/ApplyAdoBranchNameWorkaround.yml
@@ -1,0 +1,18 @@
+## @file
+# Azure Pipelines step template to apply a workaround for branch names
+# on Azure DevOps (ADO).
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+# $System.PullRequest.targetBranch looks like "dev/whatever" on GitHub,
+# but looks like "refs/heads/dev/whatever" on DevOps. The DevOps version
+# can't be used for comparison for the PR Eval.
+- powershell:
+    $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
+    Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
+  displayName: Apply Branch Name Workaround
+  condition: condition: and(eq(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.TargetBranch'], 'refs/heads/'))

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -54,6 +54,8 @@ steps:
 # Set default
 - bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
+- template: ApplyAdoBranchNameWorkaround.yml
+
 # trim the package list if this is a PR
 - task: CmdLine@1
   displayName: Check if ${{ parameters.build_pkg }} Needs Testing

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -65,14 +65,7 @@ steps:
     echo "##vso[task.setvariable variable=pkgs_to_build]${{ parameters.build_pkgs }}"
     echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
-# $System.PullRequest.targetBranch looks like "dev/whatever" on GitHub,
-# but looks like "refs/heads/dev/whatever" on DevOps. The DevOps version
-# can't be used for comparison for the PR Eval.
-- powershell:
-    $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
-    Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
-  displayName: Apply Branch Name Workaround
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.TargetBranch'], 'refs/heads/'))
+- template: ApplyAdoBranchNameWorkaround.yml
 
 # Trim the package list if this is a PR
 - ${{ if eq(parameters.do_pr_eval, true) }}:


### PR DESCRIPTION
Moves workaround logic for branch names on ADO to a dedicated file
so it can be shared between other templates.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>