### PR TITLE
Steps/ApplyAdoBranchNameWorkaround.yml: Fix error from conflict resolution

### DIFF
--- a/Steps/ApplyAdoBranchNameWorkaround.yml
+++ b/Steps/ApplyAdoBranchNameWorkaround.yml
@@ -15,4 +15,4 @@ steps:
     $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
     Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
   displayName: Apply Branch Name Workaround
-  condition: condition: and(eq(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.TargetBranch'], 'refs/heads/'))
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'), contains(variables['System.PullRequest.TargetBranch'], 'refs/heads/'))


### PR DESCRIPTION
Commit d6d4f56 introduced an error during conflict resolution that
adds an extra "condition" member to the powershell step.

The extra line is removed in this change.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>