### PR TITLE
SetNodeVersion.yml: Use Node.js 19.x

### DIFF
--- a/Steps/SetNodeVersion.yml
+++ b/Steps/SetNodeVersion.yml
@@ -9,5 +9,5 @@ steps:
 
 - task: NodeTool@0
   inputs:
-    versionSpec: '14.x'
+    versionSpec: '19.x'
   condition: succeeded()


### PR DESCRIPTION
Updates to the latest Node.js version to stay current. 19.x was released on 10/18/2022 per the release schedule:
https://github.com/nodejs/release#release-schedule

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>