### PR TITLE
InstallMarkdownLint.yml: Update to markdownlint-cli 0.31.1

### DIFF
--- a/Steps/InstallMarkdownLint.yml
+++ b/Steps/InstallMarkdownLint.yml
@@ -7,6 +7,6 @@
 
 steps:
 
-- script: npm install -g markdownlint-cli@0.31.0
+- script: npm install -g markdownlint-cli@0.31.1
   displayName: Install Markdown Linter
   condition: succeeded()


### PR DESCRIPTION
Updates to the latest markdownlint-cli to stay current. 0.31.1 was released
on 2/9/2022 per the version history:

https://www.npmjs.com/package/markdownlint-cli

Note: 0.32 introduces new failures in some repos that would need to be
addressed before moving to 0.32.x. 0.32.2 was specifically tested.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>