### PR TITLE
Steps/PrGate.yml: Add extra install step parameter

### DIFF
--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -42,14 +42,18 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: tool_chain_tag
-  displayName: Tool Chain (e.g. VS2022)
-  type: string
-  default: ''
+- name: extra_install_step
+  displayName: Extra Install Steps
+  type: stepList
+  default: []
 - name: install_tools
   displayName: Install Build Tools
   type: boolean
   default: true
+- name: tool_chain_tag
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
 
 steps:
 - checkout: self
@@ -104,6 +108,9 @@ steps:
     filename: stuart_update
     arguments: -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# Potential Extra steps
+- ${{ parameters.extra_install_step }}
 
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@1


### PR DESCRIPTION
Allows YAML files to pass extra install steps to take place before
build. This exactly matches the parameter currently in
Steps/BuildPlatform.yml and provides consistency in the parameter
interface between these two files.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>