### PR TITLE
Simplify job names

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -68,7 +68,7 @@ parameters:
 # Build step
 jobs:
 
-  - job: Build_${{ parameters.tool_chain_tag }}
+  - job: Build
 
     # Use matrix to speed up the build process
     strategy:

--- a/Jobs/Python/RunDevTests.yml
+++ b/Jobs/Python/RunDevTests.yml
@@ -34,7 +34,7 @@ parameters:
 
 jobs:
 
-- job: Build_and_Test_${{parameters.custom_job_name}}
+- job: Build_and_Test
 
   workspace:
     clean: all


### PR DESCRIPTION
Removes parameterized input from job names so the name is not
dependent on variable resolution.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>