### PR TITLE
Fix PR Eval typo (present since 201911)

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -64,7 +64,7 @@ steps:
   displayName: Check if ${{ parameters.build_pkg }} Needs Testing
   inputs:
     filename: stuart_pr_eval
-    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
+    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutput=true]{pkgcount}"
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
  # Setup repo

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -80,7 +80,7 @@ steps:
     inputs:
       filename: stuart_pr_eval
       # Workaround an azure pipelines bug.
-      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
+      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutput=true]{pkgcount}"
     condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - ${{ if eq(parameters.install_tools, true) }}:


### PR DESCRIPTION
Before:

  ##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}

After ("isOutpout" to "isOutput"):

  ##vso[task.setvariable variable=pkg_count;isOutput=true]{pkgcount}

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>