### PR TITLE
Update code to align with previous isOutput bug behavior

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -64,7 +64,7 @@ steps:
   displayName: Check if ${{ parameters.build_pkg }} Needs Testing
   inputs:
     filename: stuart_pr_eval
-    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutput=true]{pkgcount}"
+    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
  # Setup repo

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -80,7 +80,7 @@ steps:
     inputs:
       filename: stuart_pr_eval
       # Workaround an azure pipelines bug.
-      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build;isOutpout=true]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutput=true]{pkgcount}"
+      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
     condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - ${{ if eq(parameters.install_tools, true) }}:


### PR DESCRIPTION
Since "isOutput" was previously spelled incorrectly (see d326659), the resulting
behavior was equivalent to "isOutput" not being specified at all.

Subsequent code has been written such that it refers to the variable
as a variable set in the same job rather than a multi-job variable as
"isOutput" is used for - the code simply refers to the variable name
rather than \<step\>.\<var name\>.

This change simply removes "isOutput" so the original set of code
assumptions continue to work as before.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>