### PR TITLE
Revert container updates in 5f3c041

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -87,6 +87,10 @@ jobs:
       container: ${{ parameters.container_image }}
 
     steps:
+    # Add local path to ensure pip install modules are discoverable.
+    - ${{ if and(ne(parameters.container_image, ''), not(contains(parameters.vm_image, 'windows'))) }}:
+      - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"
+        displayName: Add User Local Bin to Path
     - ${{ parameters.extra_steps }}
     - template: ../Steps/PrGate.yml
       parameters:

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -23,7 +23,13 @@ steps:
       versionSpec: ">=3.10.6"
       architecture: x64
 
-- script: sudo pip install ${{ parameters.pip_requirement_files }} --upgrade
+- script: |
+    python3 -m venv .venv
+    source .venv/bin/activate
+  displayName: Setup Python Virtual Environment (Linux)
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- script: pip install ${{ parameters.pip_requirement_files }} --upgrade
   displayName: Install and Upgrade pip Modules (Linux)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -23,12 +23,6 @@ steps:
       versionSpec: ">=3.10.6"
       architecture: x64
 
-- script: |
-    python3 -m venv .venv
-    source .venv/bin/activate
-  displayName: Setup Python Virtual Environment (Linux)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
 - script: pip install ${{ parameters.pip_requirement_files }} --upgrade
   displayName: Install and Upgrade pip Modules
   condition: succeeded()

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -30,9 +30,5 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
 - script: pip install ${{ parameters.pip_requirement_files }} --upgrade
-  displayName: Install and Upgrade pip Modules (Linux)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
-- script: pip install ${{ parameters.pip_requirement_files }} --upgrade
-  displayName: Install and Upgrade pip Modules (Windows)
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
+  displayName: Install and Upgrade pip Modules
+  condition: succeeded()


### PR DESCRIPTION
Moves pip installation behavior back to what was done before
5f3c041. After analyzing several options, including using virtual
environments, this is the path that most consistently and simply
works for container and non-container builds.

It could potentially be built upon in the future, but it gets all of
the builds functional for now.

Resolves the following warning currently issued by Linux build
agents since 5f3c041 was committed:

"WARNING: Running pip as the 'root' user can result in broken
permissions and conflicting behaviour with the system package
manager.

It is recommended to use a virtual environment instead:
https://pip.pypa.io/warnings/venv"

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>