### PR TITLE
SetupPythonPreReqs.yml: Upgrade pip and install wheel and setuptools

### DIFF
--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -23,6 +23,10 @@ steps:
       versionSpec: ">=3.10.6"
       architecture: x64
 
+- script: python -m pip install --upgrade pip setuptools wheel
+  displayName: Install Wheel and SetupTools
+  condition: succeeded()
+
 - script: pip install ${{ parameters.pip_requirement_files }} --upgrade
   displayName: Install and Upgrade pip Modules
   condition: succeeded()


### PR DESCRIPTION
Fixes #26 

Currently pip installation gives the following deprecation warnings:

```
  DEPRECATION: future is being installed using the legacy
    'setup.py install' method, because it does not have a
    'pyproject.toml' and the 'wheel' package is not installed.
    pip 23.1 will enforce this behaviour change. A possible
    replacement is to enable the '--use-pep517' option.

  Discussion can be found at https://github.com/pypa/pip/issues/8559

  Running setup.py install for future: started
  Running setup.py install for future: finished with status 'done'

  DEPRECATION: pefile is being installed using the legacy
    'setup.py install' method, because it does not have a
    'pyproject.toml' and the 'wheel' package is not installed.
    pip 23.1 will enforce this behaviour change. A possible
    replacement is to enable the '--use-pep517' option.

  Discussion can be found at https://github.com/pypa/pip/issues/8559

  Running setup.py install for pefile: started
  Running setup.py install for pefile: finished with status 'done'

  Successfully installed ...

  [notice] A new release of pip available: 22.3 -> 22.3.1
  [notice] To update, run: python.exe -m pip install --upgrade pip
```

This change resolves these errors by:

1. Upgrading to the latest pip to ensure we are compliant with
changes as soon as possible rather than deferring the issue.
2. Install `wheel` and `setuptools` before other pip modules.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>