### PR TITLE
Add reusable Stale GitHub workflow

### DIFF
--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -1,0 +1,99 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: Mu DevOps Stale Issue and PR Workflow
+
+on:
+  workflow_call:
+    inputs:
+      # Note: It is recommended to use the default value for consistency across Mu repos.
+      #       However, values can be customized by workflow callers if needed.
+      days-before-issue-stale:
+        description: Override days-before-stale for issues only
+        default: 45
+        required: false
+        type: number
+      days-before-pr-stale:
+        description: Override days-before-stale for PRs only
+        default: 60
+        required: false
+        type: number
+      days-before-issue-close:
+        description: Idle number of days before closing stale issues
+        default: 7
+        required: false
+        type: number
+      days-before-pr-close:
+        description: Idle number of days before closing stale PRs
+        default: 7
+        required: false
+        type: number
+      stale-issue-message:
+        description: Comment made on stale issues
+        default: >
+          This issue has been automatically marked as stale because it has not had
+          activity in 45 days. It will be closed if no further activity occurs within
+          7 days. Thank you for your contributions.
+        required: false
+        type: string
+      stale-pr-message:
+        description: Comment made on stale PRs
+        default: >
+          This PR has been automatically marked as stale because it has not had
+          activity in 60 days. It will be closed if no further activity occurs within
+          7 days. Thank you for your contributions.
+        required: false
+        type: string
+      close-issue-message:
+        description: Comment made on stale issues when closed
+        default: >
+          This issue has been automatically been closed because it did not have any
+          activity in 45 days and no follow up within 7 days after being marked stale.
+          Thank you for your contributions.
+        required: false
+        type: string
+      close-pr-message:
+        description: Comment made on stale PRs when closed
+        default: >
+          This pull request has been automatically been closed because it did not have any
+          activity in 60 days and no follow up within 7 days after being marked stale.
+          Thank you for your contributions.
+        required: false
+        type: string
+
+jobs:
+  stale:
+    name: Stale
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Check for Stale Items
+    - uses: actions/stale@v6
+      with:
+        days-before-issue-stale: ${{ inputs.days-before-issue-stale }}
+        days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
+        days-before-issue-close: ${{ inputs.days-before-issue-close }}
+        days-before-pr-close: ${{ inputs.days-before-pr-close }}
+        stale-issue-message: ${{ inputs.stale-issue-message }}
+        stale-pr-message: ${{ inputs.stale-pr-message }}
+        close-issue-message: ${{ inputs.close-issue-message }}
+        close-pr-message: ${{ inputs.close-pr-message }}
+        stale-issue-label: 'stale: issue'
+        stale-pr-label: 'stale: pr'
+        exempt-issue-labels:
+          - 'impact: security'
+          - 'security'
+          - 'stale: ignore'
+        exempt-issue-labels:
+          - 'impact: security'
+          - 'security'
+          - 'stale: ignore'

--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -15,27 +15,27 @@ on:
       # Note: It is recommended to use the default value for consistency across Mu repos.
       #       However, values can be customized by workflow callers if needed.
       days-before-issue-stale:
-        description: Override days-before-stale for issues only
+        description: 'Override days-before-stale for issues only'
         default: 45
         required: false
         type: number
       days-before-pr-stale:
-        description: Override days-before-stale for PRs only
+        description: 'Override days-before-stale for PRs only'
         default: 60
         required: false
         type: number
       days-before-issue-close:
-        description: Idle number of days before closing stale issues
+        description: 'Idle number of days before closing stale issues'
         default: 7
         required: false
         type: number
       days-before-pr-close:
-        description: Idle number of days before closing stale PRs
+        description: 'Idle number of days before closing stale PRs'
         default: 7
         required: false
         type: number
       stale-issue-message:
-        description: Comment made on stale issues
+        description: 'Comment made on stale issues'
         default: >
           This issue has been automatically marked as stale because it has not had
           activity in 45 days. It will be closed if no further activity occurs within
@@ -43,7 +43,7 @@ on:
         required: false
         type: string
       stale-pr-message:
-        description: Comment made on stale PRs
+        description: 'Comment made on stale PRs'
         default: >
           This PR has been automatically marked as stale because it has not had
           activity in 60 days. It will be closed if no further activity occurs within
@@ -51,7 +51,7 @@ on:
         required: false
         type: string
       close-issue-message:
-        description: Comment made on stale issues when closed
+        description: 'Comment made on stale issues when closed'
         default: >
           This issue has been automatically been closed because it did not have any
           activity in 45 days and no follow up within 7 days after being marked stale.
@@ -59,7 +59,7 @@ on:
         required: false
         type: string
       close-pr-message:
-        description: Comment made on stale PRs when closed
+        description: 'Comment made on stale PRs when closed'
         default: >
           This pull request has been automatically been closed because it did not have any
           activity in 60 days and no follow up within 7 days after being marked stale.
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Check for Stale Items
-    - uses: actions/stale@v6
+      uses: actions/stale@v6
       with:
         days-before-issue-stale: ${{ inputs.days-before-issue-stale }}
         days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
@@ -89,9 +89,5 @@ jobs:
         close-pr-message: ${{ inputs.close-pr-message }}
         stale-issue-label: 'stale: issue'
         stale-pr-label: 'stale: pr'
-        exempt-issue-labels:
-          - 'impact: security'
-          - 'state: backlog'
-        exempt-issue-labels:
-          - 'impact: security'
-          - 'state: backlog'
+        exempt-issue-labels: 'impact: security,state: backlog'
+        exempt-pr-labels: 'impact: security,state: backlog'

--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -91,9 +91,7 @@ jobs:
         stale-pr-label: 'stale: pr'
         exempt-issue-labels:
           - 'impact: security'
-          - 'security'
-          - 'stale: ignore'
+          - 'state: backlog'
         exempt-issue-labels:
           - 'impact: security'
-          - 'security'
-          - 'stale: ignore'
+          - 'state: backlog'

--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -1,6 +1,6 @@
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
 #
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # You can adjust the behavior by modifying this file.

--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -87,7 +87,7 @@ jobs:
         stale-pr-message: ${{ inputs.stale-pr-message }}
         close-issue-message: ${{ inputs.close-issue-message }}
         close-pr-message: ${{ inputs.close-pr-message }}
-        stale-issue-label: 'stale: issue'
-        stale-pr-label: 'stale: pr'
-        exempt-issue-labels: 'impact: security,state: backlog'
-        exempt-pr-labels: 'impact: security,state: backlog'
+        stale-issue-label: 'state:stale'
+        stale-pr-label: 'state:stale'
+        exempt-issue-labels: 'impact:security,state:backlog,state:under-discussion'
+        exempt-pr-labels: 'impact:security,state:backlog,state:under-discussion'


### PR DESCRIPTION
Adds a new workflow YAML file that can be reused by repos that need
to check for stale issues and pull requests (PRs).

The workflow accepts the following input values:
  - `days-before-issue-stale` - Days before an issue is stale
    - default: 45
  - `days-before-pr-stale` - Days before a PR is stale
    - default: 60
  - `days-before-issue-close` - Days before a stale issue is closed
    - default: 7
  - `days-before-pr-close` - Days before a stale PR is closed
    - default: 7
  - `stale-issue-message` - Comment made on stale issues
    - default:
      "This issue has been automatically marked as stale because it
      has not had activity in 45 days. It will be closed if no
      further activity occurs within 7 days. Thank you for your
      contributions."
  - `stale-pr-message` - Comment made on stale PRs
    - default:
      "This PR has been automatically marked as stale because it has
      not had activity in 60 days. It will be closed if no further
      activity occurs within 7 days. Thank you for your
      contributions."
  - `close-issue-message` - Comment made on stale issues when closed
    - default:
      "This issue has been automatically been closed because it did
      not have any activity in 45 days and no follow up within 7 days
      after being marked stale. Thank you for your contributions."
  - `close-pr-message` - Comment made on stale PRs when closed
    - default:
      "This pull request has been automatically been closed because
      it did not have any activity in 60 days and no follow up within
      7 days after being marked stale. Thank you for your
      contributions."

It is expected that most repos will use the default values for these
inputs to make stale behavior consistent across Project Mu repos.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>