### PR TITLE
Add Label Sync GitHub workflow

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -1,0 +1,107 @@
+# Specifies the labels used in Project Mu repositories.
+#
+# This file is meant to exactly define the labels used such that label management is consistent, centralized,
+# and tracked in source control.
+#
+# Note that:
+#   1. If a label color or description changes, the same label is updated with the new color or description.
+#   2. If a label name changes, the previous label is deleted.
+#   3. All existing labels which are not listed in the manifest will be deleted.
+#      - All issues and PRs that were previously labeled with this label are now unlabeled.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/micnncim/action-label-syncer
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+
+- name: complexity:advanced
+  description: Requires substantial background information and effort to accomplish
+  color: d35400
+- name: complexity:easy
+  description: Requires minimal background information and effort to accomplish
+  color: 229954
+- name: complexity:good-first-issue
+  description: Good for newcomers
+  color: 7057ff
+- name: complexity:intermediate
+  description: Requires intermediate background information and effort to accomplish
+  color: d4ac0d
+
+- name: impact:breaking-change
+  description: Requires integration attention
+  color: a54418
+- name: impact:non-functional
+  description: Does not have a functional impact
+  color: c2e0c6
+- name: impact:security
+  description: Has a security impact
+  color: 31df8c
+- name: impact:testing
+  description: Affects testing
+  color: d4c5f9
+
+- name: state:backlog
+  description: In the backlog
+  color: e6e8d3
+- name: state:duplicate
+  description: This issue or pull request already exists
+  color: cfd3d7
+- name: state:help-wanted
+  description: Extra attention (collaborator) is needed
+  color: 008672
+- name: state:invalid
+  description: This doesn't seem right
+  color: e4e669
+- name: state:needs-maintainer-feedback
+  description: Needs more information from a maintainer to determine next steps
+  color: e7a540
+- name: state:needs-owner
+  description: Needs an issue owner to be assigned
+  color: f9e79f
+- name: state:needs-submitter-info
+  description: Needs more information from the submitter to determine next steps
+  color: fcf3cf
+- name: state:needs-triage
+  description: Needs to triaged to determine next steps
+  color: f1c40f
+- name: state:stale
+  description: Has not been updated in a long time
+  color: c0da14
+- name: state:under-discussion
+  description: Under discussion
+  color: c5def5
+- name: state:wont-fix
+  description: This will not be worked on
+  color: ffffff
+
+- name: type:bug
+  description: Something isn't working
+  color: d73a4a
+- name: type:dependencies
+  description: Pull requests that update a dependency file
+  color: 0366d6
+- name: type:design-change
+  description: A new proposal or modification to a feature design
+  color: 5b2c6f
+- name: type:documentation
+  description: Improvements or additions to documentation
+  color: 0075ca
+- name: type:enhancement
+  description: New feature or pull request
+  color: a2eeef
+- name: type:feature-request
+  description: A new feature proposal
+  color: a9dfbf
+- name: type:notes
+  description: Notes from an organized meeting
+  color: d9ee5d
+- name: type:submodules
+  description: Pull requests that update submodules
+  color: 000000
+- name: type:question
+  description: Further information is requested
+  color: d876e3

--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -1,0 +1,56 @@
+# This workflow syncs GitHub labels to the integrating repository.
+#
+# The labels are declaratively defined in .github/Labels.yml.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/micnncim/action-label-syncer
+
+name: Mu DevOps Git Label Sync Workflow
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/Labels.yml
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Project Mu Public Archived Repos for Reference:
+      #   - microsoft/mu_build
+      #   - microsoft/mu_common_intel_adv_features
+      #   - microsoft/mu_pip_build
+      #   - microsoft/mu_pip_environment
+      #   - microsoft/mu_pip_python_library
+
+      - name: Sync Labels
+        uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          manifest: .github/Labels.yml
+          repository: |
+            microsoft/mu
+            microsoft/mu_basecore
+            microsoft/mu_common_intel_min_platform
+            microsoft/mu_crypto_release
+            microsoft/mu_devops
+            microsoft/mu_feature_config
+            microsoft/mu_feature_ipmi
+            microsoft/mu_feature_mm_supv
+            microsoft/mu_feature_uefi_variable
+            microsoft/mu_oem_sample
+            microsoft/mu_plus
+            microsoft/mu_siicon_arm_tiano
+            microsoft/mu_silicon_intel_tiano
+            microsoft/mu_tiano_platforms
+            microsoft/mu_tiano_plus
+          token: ${{ secrets.MU_REPO_LABEL_SYNCER }}


### PR DESCRIPTION
Adds a new workflow and accompanying manifest that specifies labels
used in Project Mu to exclusively control label management from
this centralized repository.

- `.github/Labels.yml` - Centralized label manifest for Project Mu
- `.github/workflows/LabelSyncer.yml` - Single GitHub Action to apply
  labels in the label manifest to all Project Mu repos anytime the label
  manifest is updated

Repos can be specified directly in the GitHub Action run in this repo
(.github/workflows/LabelSyncer.yml). There is no need to update any
files in the repos this workflow applies to at all.

This has the benefit of reducing developer time working with labels
but more importantly makes labels consistent across Project Mu repos
and tracks changes to labels in Mu DevOps source history.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>