### PR TITLE
Add reusable GitHub Label Sync workflow

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -54,6 +54,11 @@
   color: 'd4c5f9'
   aliases: []
 
+- name: language:python
+  description: Pull requests that update Python code
+  color: '2b67c6'
+  aliases: []
+
 - name: state:backlog
   description: In the backlog
   color: 'e6e8d3'

--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -1,0 +1,137 @@
+# Specifies the labels used in Project Mu repositories.
+#
+# This file is meant to define the labels used such that label management is consistent, centralized,
+# and tracked in source control.
+#
+# Note that:
+#   1. If a label color or description changes, the same label is updated with the new color or description.
+#   2. If a label name changes, add the old label name to the `aliases` section. That will update the old label
+#      to the new label keeping label usage in previously labeled issues and PRs.
+#   3. All existing labels which are not listed in the manifest will be retained.
+#      - We can specify to delete them in the future if desired.
+#      - Please do not duplicate or let stale labels accumulate in repos. Only repo-specific labels should
+#        be defined outside this file. Any other label should be reviewed and added to this file.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/EndBug/label-sync
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+
+- name: complexity:advanced
+  description: Requires substantial background information and effort to accomplish
+  color: 'd35400'
+  aliases: []
+- name: complexity:easy
+  description: Requires minimal background information and effort to accomplish
+  color: '229954'
+  aliases: []
+- name: complexity:good-first-issue
+  description: Good for newcomers
+  color: '7057ff'
+  aliases: []
+- name: complexity:intermediate
+  description: Requires intermediate background information and effort to accomplish
+  color: 'd4ac0d'
+  aliases: []
+
+- name: impact:breaking-change
+  description: Requires integration attention
+  color: 'a54418'
+  aliases: []
+- name: impact:non-functional
+  description: Does not have a functional impact
+  color: 'c2e0c6'
+  aliases: []
+- name: impact:security
+  description: Has a security impact
+  color: '31df8c'
+  aliases: []
+- name: impact:testing
+  description: Affects testing
+  color: 'd4c5f9'
+  aliases: []
+
+- name: state:backlog
+  description: In the backlog
+  color: 'e6e8d3'
+  aliases: []
+- name: state:duplicate
+  description: This issue or pull request already exists
+  color: 'cfd3d7'
+  aliases: []
+- name: state:help-wanted
+  description: Extra attention (collaborator) is needed
+  color: '008672'
+  aliases: []
+- name: state:invalid
+  description: This doesn't seem right
+  color: 'e4e669'
+  aliases: []
+- name: state:needs-maintainer-feedback
+  description: Needs more information from a maintainer to determine next steps
+  color: 'e7a540'
+  aliases: []
+- name: state:needs-owner
+  description: Needs an issue owner to be assigned
+  color: 'f9e79f'
+  aliases: []
+- name: state:needs-submitter-info
+  description: Needs more information from the submitter to determine next steps
+  color: 'fcf3cf'
+  aliases: []
+- name: state:needs-triage
+  description: Needs to triaged to determine next steps
+  color: 'f1c40f'
+  aliases: []
+- name: state:stale
+  description: Has not been updated in a long time
+  color: 'c0da14'
+  aliases: []
+- name: state:under-discussion
+  description: Under discussion
+  color: 'c5def5'
+  aliases: []
+- name: state:wont-fix
+  description: This will not be worked on
+  color: 'ffffff'
+  aliases: []
+
+- name: type:bug
+  description: Something isn't working
+  color: 'd73a4a'
+  aliases: []
+- name: type:dependencies
+  description: Pull requests that update a dependency file
+  color: '0366d6'
+  aliases: []
+- name: type:design-change
+  description: A new proposal or modification to a feature design
+  color: '5b2c6f'
+  aliases: []
+- name: type:documentation
+  description: Improvements or additions to documentation
+  color: '0075ca'
+  aliases: []
+- name: type:enhancement
+  description: New feature or pull request
+  color: 'a2eeef'
+  aliases: []
+- name: type:feature-request
+  description: A new feature proposal
+  color: 'a9dfbf'
+  aliases: []
+- name: type:notes
+  description: Notes from an organized meeting
+  color: 'd9ee5d'
+  aliases: []
+- name: type:submodules
+  description: Pull requests that update submodules
+  color: '000000'
+  aliases: []
+- name: type:question
+  description: Further information is requested
+  color: 'd876e3'
+  aliases: []

--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -1,0 +1,36 @@
+# This workflow syncs GitHub labels to the integrating repository.
+#
+# The labels are declaratively defined in .github/Labels.yml.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/micnncim/action-label-syncer
+
+name: Mu DevOps Git Label Sync Workflow
+
+on:
+  workflow_call:
+    inputs:
+      # Note: The caller can set a command to an empty string to skip that command
+      local_config_file:
+        description: 'Repo relative path to a repo-specific label config file'
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync Labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: |
+            https://raw.githubusercontent.com/microsoft/mu_devops/main/.github/Labels.yml
+            ${{ inputs.local_config_file }}
+
+          delete-other-labels: false

--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # For more information, see:
-# https://github.com/micnncim/action-label-syncer
+# https://github.com/EndBug/label-sync
 
 name: Mu DevOps Git Label Sync Workflow
 


### PR DESCRIPTION
Add reusable GitHub Label Sync workflow

Adds a new workflow and accompanying manifest that specifies labels
used in Project Mu to control label management from this centralized
repository.

- `.github/Labels.yml` - Centralized label manifest for Project Mu
- `.github/workflows/LabelSyncer.yml` - Single GitHub Action to apply
  labels in the label manifest to all Project Mu repos that call the
  workflow.

Repos are expected to to sync labels by calling `LabelSyncer.yml`
on a roughly consistent cadence across Project Mu.

Repos can pass a repo-specific config as an input to this reusable
workflow.

This has the benefit of reducing developer time working with labels
but more importantly makes labels consistent across Project Mu repos
and tracks changes to labels in Mu DevOps source history. Security
settings and action version management are tracked in
`LabelSyncer.yml`. Individual repos should not duplicate direct calls
to the GitHub Action.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>