### PR TITLE
Enable Stale and Label Sync Workflows in Mu DevOps [Rebase & FF]

### DIFF
--- a/.github/workflows/label-sync-for-repo.yml
+++ b/.github/workflows/label-sync-for-repo.yml
@@ -1,0 +1,21 @@
+# This workflow syncs GitHub labels to the common set of labels defined in Mu DevOps (this repo).
+#
+# All repos should sync at the same time.
+#   '0 0,12 * * *''
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Sync GitHub Labels
+
+on:
+  schedule:
+    # At minute 0 past hour 0 and 12
+    # https://crontab.guru/#0_0,12_*_*_*
+    - cron: '0 0,12 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@main

--- a/.github/workflows/stale-for-repo.yml
+++ b/.github/workflows/stale-for-repo.yml
@@ -1,0 +1,21 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: Check for Stale Issues and Pull Requests
+
+on:
+  schedule:
+    # At 23:45 on every day-of-week from Sunday through Saturday
+    # https://crontab.guru/#45_23_*_*_0-6
+    - cron: '45 23 * * 0-6'
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@main


### PR DESCRIPTION
- Adds a workflow to identify stale PRs and issues
- Adds a workflow to sync GitHub labels

See commit messages for details.

Note: These are not common / reusable workflows but changes
to actually run these workflows in this repository.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>