### PR TITLE
FileSyncer.yml: Add microsoft prefix to review team

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -46,4 +46,4 @@ jobs:
             🤖: View the [Repo File Sync Configuration File](https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml) to see how files are synced.
           PR_LABELS: type:file-sync
           SKIP_PR: false
-          TEAM_REVIEWERS: project-mu-dependency-reviewers
+          TEAM_REVIEWERS: microsoft/project-mu-dependency-reviewers


### PR DESCRIPTION
`TEAM_REVIEWERS` needs to include the organization with the team
name so "microsoft/project-mu-dependency-reviewers" instead of
"project-mu-dependency-reviewers".

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>