### PR TITLE
CONTRIBUTING.md: Fix long line for markdownlint

### DIFF
--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -32,7 +32,9 @@ move it to the relevant repo if necessary.
 Before you create a new issue, please do a search in the issues section of the relevant repo to see if the issue or
 feature request has already been filed.
 
-If you find your issue already exists, make relevant comments and add your [reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place of a "+1" comment:
+If you find your issue already exists, make relevant comments and add your
+[reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place
+of a "+1" comment:
 
 * 👍 - upvote
 * 👎 - downvote


### PR DESCRIPTION
Resolve the following markdownlint issue:

```
 CONTRIBUTING.md:35:121 MD013/line-length Line length
 [Expected: 120; Actual: 210]
```

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>