### PR TITLE
.sync/markdownlint.yaml: Templatize allowed HTML elements

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -87,7 +87,6 @@ group:
       microsoft/mu_devops
       microsoft/mu_feature_config
       microsoft/mu_feature_ipmi
-      microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample
       microsoft/mu_plus
@@ -107,6 +106,18 @@ group:
           - img
     repos: |
       microsoft/mu
+
+# CI Configuration - Markdown Lint - Mu MM Supervisor Repo Settings
+  - files:
+    - source: .sync/ci_config/.markdownlint.yaml
+      dest: .markdownlint.yaml
+      template:
+        allowed_elements:
+          - br
+          - SmmCategory
+          - PolicyAccessAttribute
+    repos: |
+      microsoft/mu_feature_mm_supv
 
 # dependabot - Track GitHub Actions and PIP Modules
   - files:

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -73,12 +73,14 @@ group:
 #   - microsoft/mu_tiano_platforms
 #     - Custom pipeline steps
 
-# CI Configuration - Markdown Lint
+# CI Configuration - Markdown Lint - Common Settings
   - files:
     - source: .sync/ci_config/.markdownlint.yaml
       dest: .markdownlint.yaml
+      template:
+        allowed_elements:
+          - br
     repos: |
-      microsoft/mu
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
@@ -93,6 +95,18 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+
+# CI Configuration - Markdown Lint - Mu Documentation Repo Settings
+  - files:
+    - source: .sync/ci_config/.markdownlint.yaml
+      dest: .markdownlint.yaml
+      template:
+        allowed_elements:
+          - br
+          - center
+          - img
+    repos: |
+      microsoft/mu
 
 # dependabot - Track GitHub Actions and PIP Modules
   - files:

--- a/.sync/ci_config/.markdownlint.yaml
+++ b/.sync/ci_config/.markdownlint.yaml
@@ -17,5 +17,5 @@
 {
   "default": true,
   "MD013": {"line_length": 120, "code_blocks": false, "tables": false},
-  "MD033": {"allowed_elements": ["br"]}
+  "MD033": {"allowed_elements": [{{ allowed_elements | dump | safe }}]}
 }


### PR DESCRIPTION
The file sync process can compile files as Nunjucks[1] templates if
the `template` field is present. In this case, allowed HTML elements
in markdown files are adjusted for the following repos:

- The mu (documentation) repo to allow `<center>` and `<img>`
  tags.
- The mu_feature_mm_supv repo to allow `<SmmCategory>` and
  `<PolicyAccessAttribute>` tags.

[1] https://mozilla.github.io/nunjucks/

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>