### PR TITLE
.sync/markdownlint.yaml: Update brace syntax

### DIFF
--- a/.sync/ci_config/.markdownlint.yaml
+++ b/.sync/ci_config/.markdownlint.yaml
@@ -17,5 +17,5 @@
 {
   "default": true,
   "MD013": {"line_length": 120, "code_blocks": false, "tables": false},
-  "MD033": {"allowed_elements": [{{ allowed_elements | dump | safe }}]}
+  "MD033": {"allowed_elements": {{ allowed_elements | dump | safe }}}
 }


### PR DESCRIPTION
The text already comes with braces, so they are not needed explicitly
in the YAML config file.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>