### PR TITLE
Add Semantic Versioning Release workflow [Rebase & FF]

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -59,6 +59,19 @@
   color: '2b67c6'
   aliases: []
 
+- name: semver:major
+  description: Pull requests that should increment the release major version
+  color: '000000'
+  aliases: []
+- name: semver:minor
+  description: Pull requests that should increment the release minor version
+  color: '000000'
+  aliases: []
+- name: semver:patch
+  description: Pull requests that should increment the release patch version
+  color: '000000'
+  aliases: []
+
 - name: state:backlog
   description: In the backlog
   color: 'e6e8d3'

--- a/.github/ReleaseDraft.yml
+++ b/.github/ReleaseDraft.yml
@@ -1,0 +1,87 @@
+# Defines the configuration used for drafting new releases.
+#
+# IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
+#
+# NOTE: `semver:major`, `semver:minor`, and `semver:patch` can be used to force that
+#       version to roll regardless of other labels.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/release-drafter/release-drafter
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: '🚀 Features & ✨ Enhancements'
+    labels:
+      - 'type:design-change'
+      - 'type:enhancement'
+      - 'type:feature-request'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type:bug'
+  - title: '🔐 Security Impacting'
+    labels:
+      - 'impact:security'
+  - title: '📖 Documentation Updates'
+    labels:
+      - 'type:documentation'
+  - title: '🛠️ Submodule Updates'
+    labels:
+      - 'type:submodules'
+
+change-template: >-
+  <ul>
+    <li>
+      $TITLE @$AUTHOR (#$NUMBER)
+      <br>
+      <details>
+        <summary>Change Details</summary>
+        <blockquote>
+          <!-- Non-breaking space to have content if body is empty -->
+          &nbsp; $BODY
+        </blockquote>
+        <hr>
+      </details>
+    </li>
+  </ul>
+
+change-title-escapes: '\<*_&@' # Note: @ is added to disable mentions
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+version-resolver:
+  major:
+    labels:
+      - 'impact:breaking-change'
+      - 'semver:major'
+  minor:
+    labels:
+      - 'semver:minor'
+      - 'type:design-change'
+      - 'type:enhancement'
+      - 'type:feature-request'
+  patch:
+    labels:
+      - 'impact:non-functional'
+      - 'semver:patch'
+      - 'type:bug'
+      - 'type:documentation'
+  default: patch
+
+exclude-labels:
+  - 'type:file-sync'
+  - 'type:notes'
+  - 'type:question'
+
+exclude-contributors:
+  - 'uefibot'

--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -1,0 +1,39 @@
+# This workflow automatically drafts new project releases so it is obvious
+# what a current release will look like at any time.
+#
+# It takes advantage of the labels used in Project Mu to automatically categorize
+# the types of changes in a given release. In addition, the semantic version of
+# the code is constantly maintained based on Project Mu label conventions to ensure
+# semantic versioning is followed and a release version is always ready.
+#
+# Project Mu repos are encouraged to use this reusable workflow if this release
+# workflow makes sense in their repo.
+#
+# The release draft configuration is defined in:
+#   - .github/ReleaseDraft.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/release-drafter/release-drafter
+
+name: Mu DevOps Release Draft Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build the New Release Draft
+        id: update_draft
+        uses: release-drafter/release-drafter@v5.21.1
+        with:
+          # Note: Path is relative to .github/
+          config-name: ReleaseDraft.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -348,6 +348,15 @@ group:
     repos: |
       microsoft/mu_devops
 
+# Leaf Workflow - Release Draft
+  - files:
+    - source: .sync/workflows/leaf/release-draft.yml
+      dest: .github/workflows/release-draft.yml
+      template:
+        trigger_branch_name: 'main'
+    repos: |
+      microsoft/mu_devops
+
 # Pull Request Template - Common Template
   - files:
     - source: .sync/github_templates/pull_requests/pull_request_template.md

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -1,0 +1,30 @@
+# This workflow automatically drafts new project releases so it is obvious
+# what a current release will look like at any time.
+#
+# It takes advantage of the labels used in Project Mu to automatically categorize
+# the types of changes in a given release. In addition, the semantic version of
+# the code is constantly maintained based on Project Mu label conventions to ensure
+# semantic versioning is followed and a release version is always ready.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/release-drafter/release-drafter
+
+name: Update Release Draft
+
+on:
+  push:
+    branches:
+      - {{ trigger_branch_name }}
+
+jobs:
+  draft:
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@main

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -2,13 +2,16 @@
 Project MU Developer Operations (DevOps) Repository
 ===================================================
 
-|Latest Mu DevOps Release Version (latest SemVer)| |Sync Mu DevOps Files to Mu Repos|
-
-.. |Sync Mu DevOps Files to Mu Repos| image:: https://github.com/microsoft/mu_devops/actions/workflows/FileSyncer.yml/badge.svg
-   :target: https://github.com/microsoft/mu_devops/actions/workflows/FileSyncer.yml
+|Latest Mu DevOps Release Version (latest SemVer)| |Commits Since Last Release| |Sync Mu DevOps Files to Mu Repos|
 
 .. |Latest Mu DevOps Release Version (latest SemVer)| image:: https://img.shields.io/github/v/release/microsoft/mu_devops?label=Latest%20Release
    :target: https://github.com/microsoft/mu_devops/releases/latest
+
+.. |Commits Since Last Release| image:: https://img.shields.io/github/commits-since/microsoft/mu_devops/latest/main?include_prereleases
+   :target: https://github.com/microsoft/mu_devops/releases
+
+.. |Sync Mu DevOps Files to Mu Repos| image:: https://github.com/microsoft/mu_devops/actions/workflows/FileSyncer.yml/badge.svg
+   :target: https://github.com/microsoft/mu_devops/actions/workflows/FileSyncer.yml
 
 This repository is part of Project Mu.  Please see Project Mu for details https://microsoft.github.io/mu
 
@@ -18,6 +21,10 @@ for other Project Mu repositories.
 Many of these files are generic YAML templates that can be combined together to compose a fully functional pipeline.
 
 Python based code leverages `edk2-pytools` to support cross platform building and execution.
+
+You can find a high-level summary of the latest changes since the last release by viewing the `latest draft release`_.
+
+.. _`latest draft release`: https://github.com/microsoft/mu_devops/releases
 
 Continuous Integration (CI)
 ===========================
@@ -123,6 +130,29 @@ This is provided by the `.github/workflows/Stale.yml` reusable workflow.
 
 Individual repositories can control the label and time settings but it is strongly recommended to use the default
 values defined in the reusable workflow for consistency.
+
+Release Drafting
+----------------
+
+In order to ensure semantic versioning is followed based on well-defined labels used in Project Mu pull requests, the
+release drafting process is automated. On every PR merge, a draft release is updated that contains the PR change entry
+categorized according to the labels with the semantic version of the draft release updated according to the semantic
+version specification.
+
+This means, that the details for an upcoming release are always available, the release format is consistent across
+Project Mu repos, and semantic versioning is followed consistently.
+
+The draft release should be converted to an actual release any time the minor or major version is updated by a change.
+
+To see more about this flow look in these files:
+
+- The main reusable workflow file:
+  - .github/workflows/ReleaseDrafter.yml
+- The configuration file for the reusable workflow:
+  - .github/ReleaseDraft.yml
+
+A Project Mu repo simply needs to sync `.sync/workflows/leaf/release-draft.yml` to their repo and adjust any parameters
+needed in the sync process (like repo default branch name) and the release draft workflow will run in the repo.
 
 Links
 =====


### PR DESCRIPTION
Closes #50

Adds a new workflow and accompanying configuration files that allow
releases to automatically be drafted in repos as pull requests are
completed.

Semantic versioning is automatically determined based on the standard
set of Project Mu labels associated with the pull request.

The types of changes (e.g. bug fix, new feature, etc.) are
automatically categorized in the pull request based on the labels as
well.

This makes tracking the new Semantic Version based on the type of
changes automatic and a release is always ready. In between releases,
the draft is a nice way to see a high-level delta since the last
release.

- `.github/ReleaseDrafter.yml` - Single reusable workflow to maintain
  a release draft as pull requests complete.
- `.github/ReleaseDraft.yml` - Configuration file for the
  ReleaseDrafter workflow. Defines label meanings for releases and
  how releases should be drafted.
- `.sync/workflows/leaf/release-draft.yml` - A leaf workflow that can
  be synced to repos to trigger the reusable workflow in Mu DevOps.

Project Mu repos can easily opt into consistent release drafting by
including this leaf workflow via file sync.

---

I decided to allow dependabot changes into release and just not include
file sync changes since those are dev ops related and already tracked in
the mu_devops releases where they're more relevant.