### PR TITLE
Add Issue Triage workflow

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -157,3 +157,16 @@
   description: Further information is requested
   color: 'd876e3'
   aliases: []
+
+- name: urgency:low
+  description: Little to no impact
+  color: '00d26a'
+  aliases: []
+- name: urgency:medium
+  description: Important with a moderate impact
+  color: 'fcd53f'
+  aliases: []
+- name: urgency:high
+  description: Significant with a critical impact
+  color: 'ff6723'
+  aliases: []

--- a/.github/workflows/IssueTriager.yml
+++ b/.github/workflows/IssueTriager.yml
@@ -1,0 +1,42 @@
+# This workflow assists with initial triage of new issues by applying
+# labels based on data provided in the issue.
+#
+# Configuration file that maps issue form input values to labels:
+#   advanced-issue-labeler.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/stefanbuck/github-issue-parser
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+name: Issue Triage Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  triage_issues:
+    name: Triage Issues
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        template: [ bug_report.yml, documentation_request.yml, feature_request.yml ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse Issue Form
+        uses: stefanbuck/github-issue-parser@v2
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Apply Labels from Triage
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -295,6 +295,31 @@ group:
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
 
+# Leaf Workflow - Issue Triage
+  - files:
+    - source: .sync/workflows/leaf/triage-issues.yml
+      dest: .github/workflows/triage-issues.yml
+    # Note: This file name (`advanced-issue-labeler.yml`) and path (`/.github/`) is
+    #       not configurable right now. Otherwise, this would get placed in a file
+    #       at `.github/workflows/triage-issues/issue-label-mapping.yml`.
+    - source: .sync/workflows/config/triage-issues/advanced-issue-labeler.yml
+      dest: .github/advanced-issue-labeler.yml
+    repos: |
+      microsoft/mu
+      microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
+      microsoft/mu_crypto_release
+      microsoft/mu_feature_config
+      microsoft/mu_feature_ipmi
+      microsoft/mu_feature_mm_supv
+      microsoft/mu_feature_uefi_variable
+      microsoft/mu_oem_sample
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_platforms
+      microsoft/mu_tiano_plus
+
 # Leaf Workflow - Label Sync
   - files:
     - source: .sync/workflows/leaf/label-sync.yml

--- a/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
+++ b/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
@@ -1,0 +1,42 @@
+# Defines the mappings between GitHub issue responses and labels applied to the issue
+# for Project Mu repos.
+#
+# IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+
+policy:
+  - template: [bug_report.yml, documentation_request.yml, feature_request.yml]
+    section:
+
+      # Issue Template - Urgency Dropdown
+      - id: ['urgency']
+        block-list: []
+        label:
+          - name: 'urgency:low'
+            keys: ['Low']
+          - name: 'urgency:medium'
+            keys: ['Medium']
+          - name: 'urgency:high'
+            keys: ['High']
+
+      # Issue Template - Fix Owner Dropdown
+      - id: ['fix_owner', 'request_owner']
+        block-list: []
+        label:
+          - name: 'state:needs-owner'
+            keys: [
+              'Someone else needs to fix it',
+              'Someone else needs to make the change',
+              'Someone else needs to implement the feature'
+              ]
+          - name: 'state:needs-triage'
+            keys: [
+              'Someone else needs to fix it',
+              'Someone else needs to make the change',
+              'Someone else needs to implement the feature'
+              ]

--- a/.sync/workflows/leaf/triage-issues.yml
+++ b/.sync/workflows/leaf/triage-issues.yml
@@ -1,0 +1,22 @@
+# This workflow assists with initial triage of new issues by applying
+# labels based on data provided in the issue.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Initial Triage for New Issue
+
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  sync:
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@main

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -154,6 +154,22 @@ To see more about this flow look in these files:
 A Project Mu repo simply needs to sync `.sync/workflows/leaf/release-draft.yml` to their repo and adjust any parameters
 needed in the sync process (like repo default branch name) and the release draft workflow will run in the repo.
 
+Initial Issue Triage
+--------------------
+
+This repo syncs `GitHub issue form templates`_ to many Project Mu repos. Part of initial triage for incoming issues
+involves parsing data in the issue form to apply the appropriate labels so the issue is ready for triage by a human.
+
+Issues need to be triaged by a human when the `state:needs-triage` label is present. This workflow can parse details
+provided in issue forms to apply additional labels. For example, the `state:needs-owner` label is applied if the user
+indicates they are not fixing the issue, the `urgency:<level>` label is applied based on user selection in the urgency
+dropdown, etc.
+
+A Project Mu repo simply needs to sync `.sync/workflows/leaf/triage-issues.yml` to their repo and the issue triage
+workflow will run in the repo.
+
+.. _`GitHub issue form templates`: https://github.com/microsoft/mu_devops/tree/main/.sync/github_templates/ISSUE_TEMPLATE
+
 Links
 =====
 - `Basic Azure Landing Site <https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops>`_


### PR DESCRIPTION
Closes #54 

Adds a new workflow and accompanying configuration files that
apply labels to new issues based on options chosen by the submitter
in an issue form.

- `.github/IssueTriager.yml` - Single reusable workflow to apply
  labels to issues based on user input in issue forms.
- `.sync/workflows/config/triage-issues/advanced-issue-labeler.yml` -
  Configures how labels are applied to issues based on issue form
  input.
- `.sync/workflows/leaf/triage-issues.yml` - A leaf workflow that can
  be synced to repos to trigger the reusable workflow in Mu DevOps.

This change also enables file syncing of this action to all repos
that issue forms are currently being synced to.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>