### PR TITLE
.sync/azure-pipelines: Swap CLANGPDB VM image name

### DIFF
--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-CLANGPDB.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-CLANGPDB.yml
@@ -27,7 +27,7 @@ resources:
 variables:
 - group: architectures-x86-64
 - group: tool-chain-clangpdb
-- group: tool-chain-clangpdb-windows-vm-image
+- group: tool-chain-clangpdb-ubuntu-vm-image
 
 jobs:
 - template: Matrix-Build-Job-Clang.yml

--- a/.sync/azure_pipelines/matrix_dependent/Windows-CLANGPDB.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Windows-CLANGPDB.yml
@@ -27,7 +27,7 @@ resources:
 variables:
 - group: architectures-x86-64
 - group: tool-chain-clangpdb
-- group: tool-chain-clangpdb-ubuntu-vm-image
+- group: tool-chain-clangpdb-windows-vm-image
 
 jobs:
 - template: Matrix-Build-Job-Clang.yml


### PR DESCRIPTION
After this change:
  - `Ubuntu-CLANGPDB.yml`
    - Uses: `tool-chain-clangpdb-ubuntu-vm-image`
  - `Windows-CLANGPDB.yml`
    - Uses: `tool-chain-clangpdb-windows-vm-image`

These were previously reversed.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>