### PR TITLE
Add reusable Auto Merge workflow

### DIFF
--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -1,0 +1,43 @@
+# This workflow automatically merges pull requests under certain
+# conditions in Project Mu repos.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/pascalgn/automerge-action
+
+name: Auto Merge Pull Request Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  auto_merge:
+    name: Merge
+    runs-on: ubuntu-latest
+
+    # The action cannot take multiple authors right now, so call with each author
+    # separately.
+    strategy:
+      matrix:
+        author: [ "dependabot[bot]", "uefibot" ]
+
+    steps:
+      - name: Auto Merge
+        id: auto_merge
+        uses: pascalgn/automerge-action@v0.15.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_FILTER_AUTHOR: "${{ matrix.author }}"
+          MERGE_FORKS: "false"          # dependabot and uefibot come from local repo branches - forks not needed
+          MERGE_LABELS: "!state:duplicate,!state:invalid,!state:needs-maintainer-feedback,!state:needs-submitter-info,!state:under-discussion,!state:wont-fix,!type:notes,!type:question"
+          MERGE_METHOD: "squash"        # Default merge method squash (instead of "merge")
+          MERGE_REMOVE_LABELS: = ""     # Do not remove any labels from a PR after merge
+          MERGE_REQUIRED_APPROVALS: "0" # Auto merge these PRs without human reviewers involved (need to pass PR gates)
+          MERGE_RETRIES: "6"            # Check if PR status checks pass up to 6 times
+          MERGE_RETRY_SLEEP: "10000"    # Check if PR status checks are met every 10 secs (6 * 10 = check over 1 min)
+          UPDATE_LABELS: ""             # Always update these PRs if needed to merge
+          UPDATE_METHOD: "rebase"       # Default PR update method rebase (instead of "merge")
+          UPDATE_RETRIES: "2"           # Check if an update is needed up to 2 times
+          UPDATE_RETRY_SLEEP: "30000"   # Check if an update is needed every 30 secs (2 * 30 = check over ~1 min)

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -295,6 +295,27 @@ group:
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
 
+# Leaf Workflow - Auto Merger
+  - files:
+    - source: .sync/workflows/leaf/auto-merge.yml
+      dest: .github/workflows/auto-merge.yml
+    repos: |
+      microsoft/mu
+      microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
+      microsoft/mu_crypto_release
+      microsoft/mu_devops
+      microsoft/mu_feature_config
+      microsoft/mu_feature_ipmi
+      microsoft/mu_feature_mm_supv
+      microsoft/mu_feature_uefi_variable
+      microsoft/mu_oem_sample
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_platforms
+      microsoft/mu_tiano_plus
+
 # Leaf Workflow - Issue Triage
   - files:
     - source: .sync/workflows/leaf/triage-issues.yml

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -1,0 +1,39 @@
+# This workflow automatically merges pull requests under certain conditions.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# NOTE: This file uses a reusable workflow. Do not make changes to the file that should be made
+#       in the common/reusable workflow.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Auto Merge Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - labeled
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+      - unlabeled
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+
+jobs:
+  merge_check:
+    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@main

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -170,6 +170,27 @@ workflow will run in the repo.
 
 .. _`GitHub issue form templates`: https://github.com/microsoft/mu_devops/tree/main/.sync/github_templates/ISSUE_TEMPLATE
 
+Auto Merge
+----------
+
+As automated bots pick up mundane tasks like syncing PIP module updates, submodules, files, and so on, an increasing
+number of pull requests can accumulate that essentially update dependencies we expect to be updated over time. In most
+cases, we simply care that the new update passes CI checks.
+
+Therefore, Project Mu repos auto merge certain pull requests to reduce human burden of approving these requests in all
+of the Project Mu repos. Individual repos can opt out of this functionality by removing the leaf workflow sync to their
+repo, however, it is recommended to keep this flow enabled for consistency across all repos.
+
+To see more about this flow look in these files:
+
+- The main reusable workflow file:
+  - `.github/workflows/AutoMerger.yml`
+- The leaf workflow
+  - `.sync/workflows/leaf/auto-merge.yml`
+
+A Project Mu repo simply needs to sync `.sync/workflows/leaf/auto-merge.yml` to their repo in `Files.yml` and the
+auto merge workflow will run in the repo.
+
 Links
 =====
 - `Basic Azure Landing Site <https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops>`_


### PR DESCRIPTION
Adds a new workflow that automatically merges pull requests in
Project Mu repos under certain conditions.

As automated bots pick up mundane tasks like syncing PIP module
updates, submodules, files, and so on, an increasing number of
pull requests can accumulate that essentially update dependencies
we expect to be updated over time. In most cases, we simply care
that the new update passes CI checks.

This workflow is currently configured to automerge dependabot and
uefibot pull requests.

Files added:

- `.github/workflows/AutoMerger.yml` - Reusable workflow to auto
  merge pull requests that meet given criteria.
- `.sync/workflows/leaf/auto-merge.yml` - Leaf workflow file to
  auto merge pull requests in a given repo.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>