### PR TITLE
.sync: Set recent workflows to a fixed version of mu_devops

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -299,6 +299,7 @@ group:
   - files:
     - source: .sync/workflows/leaf/auto-merge.yml
       dest: .github/workflows/auto-merge.yml
+      template: true
     repos: |
       microsoft/mu
       microsoft/mu_basecore
@@ -320,6 +321,7 @@ group:
   - files:
     - source: .sync/workflows/leaf/triage-issues.yml
       dest: .github/workflows/triage-issues.yml
+      template: true
     # Note: This file name (`advanced-issue-labeler.yml`) and path (`/.github/`) is
     #       not configurable right now. Otherwise, this would get placed in a file
     #       at `.github/workflows/triage-issues/issue-label-mapping.yml`.

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -13,6 +13,8 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
+{% import '../../Version.njk' as sync_version -%}
+
 name: Auto Merge Pull Request
 
 on:
@@ -36,4 +38,4 @@ on:
 
 jobs:
   merge_check:
-    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@main
+    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -18,6 +18,8 @@
 # For more information, see:
 # https://github.com/release-drafter/release-drafter
 
+{% import '../../Version.njk' as sync_version -%}
+
 name: Update Release Draft
 
 on:
@@ -27,4 +29,4 @@ on:
 
 jobs:
   draft:
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@main
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/triage-issues.yml
+++ b/.sync/workflows/leaf/triage-issues.yml
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
+{% import '../../Version.njk' as sync_version -%}
+
 name: Initial Triage for New Issue
 
 on:
@@ -19,4 +21,4 @@ on:
 
 jobs:
   sync:
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@main
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@{{ sync_version.mu_devops }}


### PR DESCRIPTION
When some workflows were added recently, the reusable workflow file
that the leaf files depend on in mu_devops did not exist yet.

Therefore, those leaf files depended on the `main` branch instead
of a mu_devops release tag as the files would be in the `main`
branch as soon as the PR was merged.

Now that all of the reusable workflows are in a tagged release
(as of the `v1.3.0` release), this change sets them to a fixed version
of Mu DevOps as well.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>