### PR TITLE
.sync/workflows: Add file sync notice to some files

### DIFF
--- a/.sync/workflows/config/label-issues/file-paths.yml
+++ b/.sync/workflows/config/label-issues/file-paths.yml
@@ -1,5 +1,11 @@
 # Specifies labels to apply to issues and pull requests based on file path patterns in Project Mu repositories.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/.sync/workflows/config/label-issues/regex-pull-requests.yml
+++ b/.sync/workflows/config/label-issues/regex-pull-requests.yml
@@ -1,5 +1,11 @@
 # Specifies labels to apply to pull requests in Project Mu repositories based on regular expressions.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
+++ b/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
@@ -3,6 +3,12 @@
 #
 # IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #


### PR DESCRIPTION
These files were added without the notice in the copyright area that
states the files should be updated in mu_devops.

This change adds the notice.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>