### PR TITLE
Add auto approval for auto merge

### DIFF
--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -17,7 +17,7 @@ jobs:
     name: Bot Approval
     if: |
       github.event_name == 'pull_request_target' &&
-      github.event.action == 'opened' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
       (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: hmarr/auto-approve-action@v3
         with:
-          github-token: ${{ secrets.MU_BOT_AUTO_MERGE }}
+          github-token: ${{ secrets.PROJECT_MU_BOT_TOKEN }}
           review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
 
   auto_merge:
@@ -49,14 +49,14 @@ jobs:
         id: auto_merge
         uses: pascalgn/automerge-action@v0.15.5
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PROJECT_MU_BOT_TOKEN }}"
           MERGE_ERROR_FAIL: "false"     # Do not fail if an auto merge couldn't happen
           MERGE_FILTER_AUTHOR: "${{ matrix.author }}"
           MERGE_FORKS: "false"          # dependabot and uefibot come from local repo branches - forks not needed
           MERGE_LABELS: "!state:duplicate,!state:invalid,!state:needs-maintainer-feedback,!state:needs-submitter-info,!state:under-discussion,!state:wont-fix,!type:notes,!type:question"
           MERGE_METHOD: "squash"        # Default merge method squash (instead of "merge")
           MERGE_REMOVE_LABELS: = ""     # Do not remove any labels from a PR after merge
-          MERGE_REQUIRED_APPROVALS: "0" # Auto merge these PRs without human reviewers involved (need to pass PR gates)
+          MERGE_REQUIRED_APPROVALS: "2" # Two PRs can be humans or bots (need to pass PR gates)
           MERGE_RETRIES: "6"            # Check if PR status checks pass up to 6 times
           MERGE_RETRY_SLEEP: "10000"    # Check if PR status checks are met every 10 secs (6 * 10 = check over 1 min)
           UPDATE_LABELS: ""             # Always update these PRs if needed to merge

--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -13,6 +13,27 @@ on:
   workflow_call:
 
 jobs:
+  bot_approval:
+    name: Bot Approval
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'opened' &&
+      (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
+
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.MU_BOT_AUTO_MERGE }}
+          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
+
   auto_merge:
     name: Merge
     runs-on: ubuntu-latest
@@ -29,6 +50,7 @@ jobs:
         uses: pascalgn/automerge-action@v0.15.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_ERROR_FAIL: "false"     # Do not fail if an auto merge couldn't happen
           MERGE_FILTER_AUTHOR: "${{ matrix.author }}"
           MERGE_FORKS: "false"          # dependabot and uefibot come from local repo branches - forks not needed
           MERGE_LABELS: "!state:duplicate,!state:invalid,!state:needs-maintainer-feedback,!state:needs-submitter-info,!state:under-discussion,!state:wont-fix,!type:notes,!type:question"

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -38,5 +38,10 @@ on:
 
 jobs:
   merge_check:
+    if: |
+      ((github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review') &&
+       (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot')) ||
+      ((github.event_name == 'check_suite') &&
+       (github.event.check_suite.sender.login == 'dependabot[bot]' || github.event.check_suite.sender.login == 'uefibot'))
     uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}
     secrets: inherit

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -39,3 +39,4 @@ on:
 jobs:
   merge_check:
     uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}
+    secrets: inherit


### PR DESCRIPTION
The auto merge process needs two reviews to meet Project Mu branch
protection policy requirements. This change auto approves dependency
update pull requests so they can be auto merged.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>