### PR TITLE
Add pull-request best practices guide

### DIFF
--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -78,7 +78,8 @@ Implementation is ultimately composed of functions as logical units of code.
 To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your
 function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
 
-Furthermore, files contain functions. Files are easier to review and maintain if they contain functions that serves a
+Files are easier to review and maintain if they contain functions that serves a
+
 similar purpose. Limit files to around 1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of
 code, it may have functions that should be split into separate files.
 

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -64,7 +64,8 @@ To keep code digestible, you may consider breaking large pull requests into thre
 
 1. **Interfaces**: .h, .inf, .dec, documentation
 2. **Implementation**: .c, unit tests, unit test build file; unit tests should build and run at this point
-3. **Integration/Build**: .dec, .dsc, .fdf, integration tests; code added to platform and affects downstream consumers
+3. **Integration/Build**: .dec, .dsc, .fdf, (.yml) configuration files, integration tests; code added to platform and affects
+        downstream consumers
 
 By breaking the pull request into these three categories, the pull request reviewers can digest each piece independently.
 

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -46,6 +46,35 @@ If you cannot find an existing issue that describes your bug or feature, create 
 Please continue to follow your request after it is submitted to assist with any additional information that might be
 requested.
 
+### Pull Request Best Practices
+
+Generally pull requests for UEFI code can become large and difficult to review due to the large number of build and
+configuration files. To aid maintainers in reviewing your code we suggest adhering to the following guidelines:
+
+1. Do keep code reviews single purpose; don't add more than one feature at a time.
+2. Do fix bugs independently of adding features.
+3. Do provide documentation and unit tests.
+4. Do introduce code in digestable amounts; don't add more than 1000 lines per pull request.
+
+As a general guide to help keep code digestable, you may consider breaking large pull requests into three smaller
+pull requests the the general guide:
+
+1. Interfaces (.h, .inf, documentation)
+2. Implementatation (.c, unit-tests, unit-test build file); unit tests should build and run at this point
+3. Integration/Build (.dec, .dsc, .fdf, integration tests); code added to platform and affects downstream consumers
+
+By breaking the pull request into these three steps the reviewer can digest each piece independently, but each without
+risk of breaking the main branch since without step 3 the code is shipping darkly (not directly integrated into the
+build).
+
+If any of these 3 pull requests is still larger than 1000 lines of code consider breaking the pull request down by the
+following boundaries:
+
+1. By .inf file; break each library/driver into its own 3 part pull request
+2. By .c file; for large drivers break each .c file and its tests into a separate pull request
+
+Feel free to create a draft pull request and ask for suggestions on how to split the pull request if you are unsure.
+
 ## Thank You
 
 Thank you for your interest in Project Mu and taking the time to contribute!

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -60,14 +60,16 @@ configuration files. To aid maintainers in reviewing your code, we suggest adher
 
 #### Code Categories
 
-To keep code digestible, you may consider breaking large pull requests into three categories of commits within the pull request.
+To keep code digestible, you may consider breaking large pull requests into three categories of commits within the pull
+request.
 
 1. **Interfaces**: .h, .inf, .dec, documentation
 2. **Implementation**: .c, unit tests, unit test build file; unit tests should build and run at this point
-3. **Integration/Build**: .dec, .dsc, .fdf, (.yml) configuration files, integration tests; code added to platform and affects
-        downstream consumers
+3. **Integration/Build**: .dec, .dsc, .fdf, (.yml) configuration files, integration tests; code added to platform and
+   affects downstream consumers
 
-By breaking the pull request into these three categories, the pull request reviewers can digest each piece independently.
+By breaking the pull request into these three categories, the pull request reviewers can digest each piece
+independently.
 
 If your commits are still very large after adhering to these categories, consider further breaking the pull request
 down by library/driver; break each component into its own commit.
@@ -79,10 +81,9 @@ Implementation is ultimately composed of functions as logical units of code.
 To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your
 function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
 
-Files are easier to review and maintain if they contain functions that serves a
-
-similar purpose. Limit files to around 1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of
-code, it may have functions that should be split into separate files.
+Files are easier to review and maintain if they contain functions that serves similar purpose. Limit files to around
+1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of code, it may have functions that should
+be split into separate files.
 
 ---
 

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -53,8 +53,8 @@ configuration files. To aid maintainers in reviewing your code, we suggest adher
 
 1. Do keep code reviews single purpose; don't add more than one feature at a time.
 2. Do fix bugs independently of adding features.
-5. Do provide documentation and unit tests.
-7. Do introduce code in digestible amounts.
+3. Do provide documentation and unit tests.
+4. Do introduce code in digestible amounts.
    - If the contribution logically be broken up into separate pull requests that independently build and function successfully, do use multiple pull requests.
 
 #### Code Categories

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -48,33 +48,40 @@ requested.
 
 ### Pull Request Best Practices
 
-Generally pull requests for UEFI code can become large and difficult to review due to the large number of build and
-configuration files. To aid maintainers in reviewing your code we suggest adhering to the following guidelines:
+Pull requests for UEFI code can become large and difficult to review due to the large number of build and
+configuration files. To aid maintainers in reviewing your code, we suggest adhering to the following guidelines:
 
 1. Do keep code reviews single purpose; don't add more than one feature at a time.
 2. Do fix bugs independently of adding features.
-3. Do provide documentation and unit tests.
-4. Do introduce code in digestable amounts; don't add more than 1000 lines per pull request.
+5. Do provide documentation and unit tests.
+7. Do introduce code in digestible amounts.
+   - If the contribution logically be broken up into separate pull requests that independently build and function successfully, do use multiple pull requests.
 
-As a general guide to help keep code digestable, you may consider breaking large pull requests into three smaller
-pull requests the the general guide:
+#### Code Categories
 
-1. Interfaces (.h, .inf, documentation)
-2. Implementatation (.c, unit-tests, unit-test build file); unit tests should build and run at this point
-3. Integration/Build (.dec, .dsc, .fdf, integration tests); code added to platform and affects downstream consumers
+To keep code digestible, you may consider breaking large pull requests into three categories of commits within the pull request.
 
-By breaking the pull request into these three steps the reviewer can digest each piece independently, but each without
-risk of breaking the main branch since without step 3 the code is shipping darkly (not directly integrated into the
-build).
+1. **Interfaces**: .h, .inf, .dec, documentation
+2. **Implementation**: .c, unit tests, unit test build file; unit tests should build and run at this point
+3. **Integration/Build**: .dec, .dsc, .fdf, integration tests; code added to platform and affects downstream consumers
 
-If any of these 3 pull requests is still larger than 1000 lines of code consider breaking the pull request down by the
-following boundaries:
+By breaking the pull request into these three categories, the pull request reviewers can digest each piece independently.
 
-1. By .inf file; break each library/driver into its own 3 part pull request
-2. By .c file; for large drivers break each .c file and its tests into a separate pull request
+If your commits are still very large after adhering to these categories, consider further breaking the pull request down by library/driver; break each component into its own commit.
+
+#### Implementation Limits
+
+Implementation is ultimately composed of functions as logical units of code.
+
+To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
+
+Furthermore, files contain functions. Files are easier to review and maintain if they contain functions that serves a similar purpose. Limit files to around 1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of code, it may have functions that should be split into separate files.
+
+---
+
+By following these guidelines, your pull requests will be reviewed faster, and you'll avoid being asked to refactor the code to follow the guidelines.
 
 Feel free to create a draft pull request and ask for suggestions on how to split the pull request if you are unsure.
-
 ## Thank You
 
 Thank you for your interest in Project Mu and taking the time to contribute!

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -55,7 +55,8 @@ configuration files. To aid maintainers in reviewing your code, we suggest adher
 2. Do fix bugs independently of adding features.
 3. Do provide documentation and unit tests.
 4. Do introduce code in digestible amounts.
-   - If the contribution logically be broken up into separate pull requests that independently build and function successfully, do use multiple pull requests.
+   * If the contribution logically be broken up into separate pull requests that independently build and function
+     successfully, do use multiple pull requests.
 
 #### Code Categories
 
@@ -67,21 +68,27 @@ To keep code digestible, you may consider breaking large pull requests into thre
 
 By breaking the pull request into these three categories, the pull request reviewers can digest each piece independently.
 
-If your commits are still very large after adhering to these categories, consider further breaking the pull request down by library/driver; break each component into its own commit.
+If your commits are still very large after adhering to these categories, consider further breaking the pull request
+down by library/driver; break each component into its own commit.
 
 #### Implementation Limits
 
 Implementation is ultimately composed of functions as logical units of code.
 
-To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
+To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your
+function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
 
-Furthermore, files contain functions. Files are easier to review and maintain if they contain functions that serves a similar purpose. Limit files to around 1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of code, it may have functions that should be split into separate files.
+Furthermore, files contain functions. Files are easier to review and maintain if they contain functions that serves a
+similar purpose. Limit files to around 1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of
+code, it may have functions that should be split into separate files.
 
 ---
 
-By following these guidelines, your pull requests will be reviewed faster, and you'll avoid being asked to refactor the code to follow the guidelines.
+By following these guidelines, your pull requests will be reviewed faster, and you'll avoid being asked to refactor the
+code to follow the guidelines.
 
 Feel free to create a draft pull request and ask for suggestions on how to split the pull request if you are unsure.
+
 ## Thank You
 
 Thank you for your interest in Project Mu and taking the time to contribute!

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -1,7 +1,7 @@
 # Preface
 
-Please ensure you have read the [contribution docs](./CONTRIBUTING.md) prior to
-submitting the pull request. In particular, [pull request guidelines](./CONTRIBUTING.md#pull-request-best-practices).
+Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior to
+submitting the pull request. In particular, [pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).
 
 ## Description
 

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -1,7 +1,8 @@
 # Preface
 
-Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior to
-submitting the pull request. In particular, [pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).
+Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
+to submitting the pull request. In particular,
+[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).
 
 ## Description
 

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -1,3 +1,8 @@
+# Preface
+
+Please ensure you have read the [contribution docs](./CONTRIBUTING.md) prior to
+submitting the pull request. In particular [pull request guidelines](./CONTRIBUTING.md#pull-request-best-practices)
+
 ## Description
 
 <_Please include a description of the change and why this change was made._>

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -3,7 +3,6 @@
 Please ensure you have read the [contribution docs](./CONTRIBUTING.md) prior to
 submitting the pull request. In particular, [pull request guidelines](./CONTRIBUTING.md#pull-request-best-practices).
 
-
 ## Description
 
 <_Please include a description of the change and why this change was made._>

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -1,7 +1,8 @@
 # Preface
 
 Please ensure you have read the [contribution docs](./CONTRIBUTING.md) prior to
-submitting the pull request. In particular [pull request guidelines](./CONTRIBUTING.md#pull-request-best-practices)
+submitting the pull request. In particular, [pull request guidelines](./CONTRIBUTING.md#pull-request-best-practices).
+
 
 ## Description
 


### PR DESCRIPTION
# Description

Adds pull request best practices to CONTRIBUTING.md and references this document + pull request best practices in the pull_request_template.md so all contributors are confronted with this guide before they open a pull request rather than afterward by the bot.

TODO:

 - [x] ensure the relative path to CONTRIBUTING.md in pull_request_template.md is correct since dependent repos have different layout
