### PR TITLE
Split approval and merge workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,6 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -44,5 +42,3 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"

--- a/.github/workflows/AutoApprover.yml
+++ b/.github/workflows/AutoApprover.yml
@@ -1,0 +1,31 @@
+# This workflow automatically approves pull requests under certain
+# conditions in Project Mu repos.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/pascalgn/automerge-action
+
+name: Auto Approve Pull Request Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  bot_approval:
+    name: Bot Approval
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
+
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.PROJECT_MU_BOT_TOKEN }}
+          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."

--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -13,28 +13,7 @@ on:
   workflow_call:
 
 jobs:
-  bot_approval:
-    name: Bot Approval
-    if: |
-      github.event_name == 'pull_request_target' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened') &&
-      (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot')
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-
-    steps:
-      - uses: hmarr/auto-approve-action@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
-
-      - uses: hmarr/auto-approve-action@v3
-        with:
-          github-token: ${{ secrets.PROJECT_MU_BOT_TOKEN }}
-          review-message: "🤖 auto approved a ${{ github.event.pull_request.user.login }} PR."
-
-  auto_merge:
+  bot_merge:
     name: Merge
     runs-on: ubuntu-latest
 
@@ -56,9 +35,8 @@ jobs:
           MERGE_LABELS: "!state:duplicate,!state:invalid,!state:needs-maintainer-feedback,!state:needs-submitter-info,!state:under-discussion,!state:wont-fix,!type:notes,!type:question"
           MERGE_METHOD: "squash"        # Default merge method squash (instead of "merge")
           MERGE_REMOVE_LABELS: = ""     # Do not remove any labels from a PR after merge
-          MERGE_REQUIRED_APPROVALS: "2" # Two PRs can be humans or bots (need to pass PR gates)
-          MERGE_RETRIES: "6"            # Check if PR status checks pass up to 6 times
-          MERGE_RETRY_SLEEP: "10000"    # Check if PR status checks are met every 10 secs (6 * 10 = check over 1 min)
+          MERGE_RETRIES: "120"          # Check if PR status checks pass up to 120 times
+          MERGE_RETRY_SLEEP: "60000"    # Check if PR status checks are met every 60 secs (60 * 120 = check over 2 hrs)
           UPDATE_LABELS: ""             # Always update these PRs if needed to merge
           UPDATE_METHOD: "rebase"       # Default PR update method rebase (instead of "merge")
           UPDATE_RETRIES: "2"           # Check if an update is needed up to 2 times

--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -46,4 +46,3 @@ jobs:
             🤖: View the [Repo File Sync Configuration File](https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml) to see how files are synced.
           PR_LABELS: type:file-sync
           SKIP_PR: false
-          TEAM_REVIEWERS: microsoft/project-mu-dependency-reviewers

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v1.4.0" %}
+{% set mu_devops = "v1.4.2" %}
 
 {# The version of the fedora-35-build container to use. #}
 {% set linux_build_container = "ghcr.io/tianocore/containers/fedora-35-build:2113a0e" %}

--- a/.sync/workflows/leaf/auto-approve.yml
+++ b/.sync/workflows/leaf/auto-approve.yml
@@ -1,4 +1,4 @@
-# This workflow automatically merges pull requests under certain conditions.
+# This workflow automatically approves pull requests under certain conditions.
 #
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.
@@ -15,18 +15,17 @@
 
 {% import '../../Version.njk' as sync_version -%}
 
-name: Auto Merge Pull Request
+name: Auto Approve Pull Request
 
 on:
   pull_request_target:
     types:
       - opened
       - reopened
-      - synchronize
 
 jobs:
-  merge_check:
+  approval_check:
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}
+    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@{{ sync_version.mu_devops }}
     secrets: inherit


### PR DESCRIPTION
Split approval and merge workflows

Splitting the workflows provides several benefits:

1. Simplifies logic due to jobs being attached to separate triggers
   relevant for the specific job.
2. Reduces number of status checks shown in PRs due to certain steps
   being skipped in irrelevant circumstances.
3. Allows better workflow reuse.

The reviewers are also dropped from dependabot PRs since the pending
team reviewer is (1) not acted upon (2) can delay PR merging if the
reviewer team has not reviewed the PR.

The version is updated in anticipation of this change. It will be
modified if the expected version changes before this PR is merged.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>