### PR TITLE
.sync/dependabot: Remove team reviewers

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -33,8 +33,6 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
@@ -43,8 +41,6 @@ updates:
     labels:
       - "type:submodules"
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -55,5 +51,3 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -32,8 +32,6 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -44,5 +42,3 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
-    reviewers:
-      - "microsoft/project-mu-dependency-reviewers"


### PR DESCRIPTION
Removes the microsoft/project-mu-dependency-reviewers team from
reviews to reduce messages with the automated workflow.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>