### PR TITLE
Add dashboard for issue triage

### DIFF
--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -38,5 +38,15 @@
     "kind": 2,
     "language": "github-issues",
     "value": "$repos is:open is:issue archived:false no:assignee"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues marked stale"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:stale"
   }
 ]

--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -1,0 +1,42 @@
+[
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "# Project Mu GitHub Open Issue Dashboard\r\n\r\nThis notebook displays [Project Mu](https://microsoft.github.io/mu/) open issues."
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "// list of project mu repos\r\n$repos=repo:repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_plus repo:microsoft/mu_tiano_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_tiano_platforms repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_feature_ipmi repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_python_library repo:microsoft/mu_pip_build repo:microsoft/mu_build repo:microsoft/mu_common_intel_adv_features"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "📬 All Open Issues"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues with no labels"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false no:label"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Open Issues with no assignee"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false no:assignee"
+  }
+]

--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -42,6 +42,16 @@
   {
     "kind": 1,
     "language": "markdown",
+    "value": "All Open Issues with needs-owner label"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:issue archived:false label:state:needs-owner"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
     "value": "All Open Issues marked stale"
   },
   {

--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -48,5 +48,15 @@
     "kind": 2,
     "language": "github-issues",
     "value": "// This needs to be bumped very occassionally (annually likely) to prevent\r\n// the maximum allowed number of results from being reached.\r\n$since=2022-01-01\r\n\r\n$repos is:closed type:pr sort:created-desc closed:>$since"
+  },
+  {
+    "kind": 1,
+    "language": "markdown",
+    "value": "All Stale PRs"
+  },
+  {
+    "kind": 2,
+    "language": "github-issues",
+    "value": "$repos is:open is:pr archived:false label:state:stale"
   }
 ]

--- a/Notebooks/ReadMe.md
+++ b/Notebooks/ReadMe.md
@@ -21,6 +21,7 @@ To view the file in the Web version of VS Code, simply open the file in GitHub a
 
 - [Project Mu Pull Request Dashboard](https://github.dev/microsoft/mu_devops/blob/main/Notebooks/PullRequests.github-issues)
 - [Project Mu Personal Issue & Pull Request Dashboard](https://github.com/microsoft/mu_devops/blob/main/Notebooks/MyPullRequests.github-issues)
+- [Project Mu Issue Dashboard](https://github.com/microsoft/mu_devops/blob/main/Notebooks/OpenIssues.github-issues)
 
 Once opened, run the same steps in [How to Use](#how-to-use) to install the extension and view the file. You can then
 save the page to your bookmarks so you can easily load it in the future.


### PR DESCRIPTION
Added a issue triage dashboard that enables queries for no assignee and no labels 