### PR TITLE
Changed links to github.dev instead of github.com

### DIFF
--- a/Notebooks/ReadMe.md
+++ b/Notebooks/ReadMe.md
@@ -20,8 +20,8 @@ To view the file in the Web version of VS Code, simply open the file in GitHub a
 `github.dev` in the URL.
 
 - [Project Mu Pull Request Dashboard](https://github.dev/microsoft/mu_devops/blob/main/Notebooks/PullRequests.github-issues)
-- [Project Mu Personal Issue & Pull Request Dashboard](https://github.com/microsoft/mu_devops/blob/main/Notebooks/MyPullRequests.github-issues)
-- [Project Mu Issue Dashboard](https://github.com/microsoft/mu_devops/blob/main/Notebooks/OpenIssues.github-issues)
+- [Project Mu Personal Issue & Pull Request Dashboard](https://github.dev/microsoft/mu_devops/blob/main/Notebooks/MyPullRequests.github-issues)
+- [Project Mu Issue Dashboard](https://github.Dev/microsoft/mu_devops/blob/main/Notebooks/OpenIssues.github-issues)
 
 Once opened, run the same steps in [How to Use](#how-to-use) to install the extension and view the file. You can then
 save the page to your bookmarks so you can easily load it in the future.


### PR DESCRIPTION
The links in Readme.md (the second and third) were to the individual files in the repo, instead of github.dev, which enables quick access to run the queries.

Changed the Dashboards for Personal Issues to use github.dev.