### PR TITLE
Steps/BuildPlatform.yml: Add Run to Shell timeout parameter

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -38,6 +38,10 @@ parameters:
   displayName: Run Flags
   type: string
   default: ''
+- name: run_timeout
+  displayName: Run Timeout (in minutes)
+  type: number
+  default: 5
 - name: install_tools
   displayName: Install Build Tools
   type: boolean
@@ -115,7 +119,7 @@ steps:
     filename: stuart_build
     arguments: -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
   condition: and(and(gt(variables.pkg_count, 0), succeeded()), eq(variables['Run'], true))
-  timeoutInMinutes: 5
+  timeoutInMinutes: ${{ parameters.run_timeout }}
 
 # Copy the build logs to the artifact staging directory
 - task: CopyFiles@2


### PR DESCRIPTION
Updates the template to allow the platform to specify a custom
timeout for running to shell.

The previous value of `5` is the default.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>