### PR TITLE
Add ability to request maintainer feedback in issues

### DIFF
--- a/.sync/github_templates/ISSUE_TEMPLATE/bug_report.yml
+++ b/.sync/github_templates/ISSUE_TEMPLATE/bug_report.yml
@@ -129,6 +129,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
   - type: textarea
     id: anything_else
     attributes:

--- a/.sync/github_templates/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.sync/github_templates/ISSUE_TEMPLATE/documentation_request.yml
@@ -41,6 +41,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
   - type: textarea
     id: anything_else
     attributes:

--- a/.sync/github_templates/ISSUE_TEMPLATE/feature_request.yml
+++ b/.sync/github_templates/ISSUE_TEMPLATE/feature_request.yml
@@ -84,6 +84,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: needs_maintainer_feedback
+    attributes:
+      label: Do you need maintainer feedback?
+      description: Indicate if you would like a maintainer to provide feedback on this submission.
+      multiple: false
+      options:
+        - No maintainer feedback needed
+        - Maintainer feedback requested
+    validations:
+      required: true
+
   - type: textarea
     id: anything_else
     attributes:

--- a/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
+++ b/.sync/workflows/config/triage-issues/advanced-issue-labeler.yml
@@ -45,3 +45,10 @@ policy:
             'Someone else needs to make the change',
             'Someone else needs to implement the feature'
             ]
+
+    # Issue Template - Needs Maintainer Feedback Dropdown
+    - id: ['needs_maintainer_feedback']
+      block-list: []
+      label:
+        - name: 'state:needs-maintainer-feedback'
+          keys: ['Maintainer feedback requested']


### PR DESCRIPTION
Closes #85 

Adds a new selection to issues to request maintainer feedback.

The default is no maintainer feedback is necessary. Opting for
maintainer feedback adds the `state:needs-maintainer-feedback`
label to the issue.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>