### PR TITLE
Add scheduled maintenance workflow

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -427,6 +427,29 @@ group:
     repos: |
       microsoft/mu_devops
 
+# Leaf Workflow - Scheduled Maintenance
+# Note: This currently sync to the same repos as the label sync since it is exclusively
+#       performing cleanup based on labels.
+  - files:
+    - source: .sync/workflows/leaf/scheduled-maintenance.yml
+      dest: .github/workflows/scheduled-maintenance.yml
+    repos: |
+      microsoft/mu
+      microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
+      microsoft/mu_crypto_release
+      microsoft/mu_devops
+      microsoft/mu_feature_config
+      microsoft/mu_feature_ipmi
+      microsoft/mu_feature_mm_supv
+      microsoft/mu_feature_uefi_variable
+      microsoft/mu_oem_sample
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_platforms
+      microsoft/mu_tiano_plus
+
 # Pull Request Template - Common Template
   - files:
     - source: .sync/github_templates/pull_requests/pull_request_template.md

--- a/.sync/workflows/leaf/scheduled-maintenance.yml
+++ b/.sync/workflows/leaf/scheduled-maintenance.yml
@@ -1,0 +1,59 @@
+# This workflow performs scheduled maintenance tasks.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# NOTE: This file uses reusable workflows. Do not make changes to the file that should be made
+#       in the common/reusable workflows.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Scheduled Maintenance
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every hour - https://crontab.guru/#0_*_*_*_*
+    - cron:  '0 * * * *'
+
+jobs:
+  repo_cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Repository Info
+        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Prune Won't Fix Pull Requests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ env.REPOSITORY_NAME }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/microsoft/${REPOSITORY}/pulls | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh pr close $html_url -c "Closed due to being marked as wont fix" --delete-branch
+            fi
+          done
+
+      - name: Prune Won't Fix Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ env.REPOSITORY_NAME }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/microsoft/${REPOSITORY}/issues | jq -r '.[]' | jq -rc '.html_url,.labels' | \
+          while read -r html_url ; do
+            read -r labels
+            if [[ $labels == *"state:wont-fix"* ]]; then
+              gh issue close $html_url -c "Closed due to being marked as wont fix" -r "not planned"
+            fi
+          done


### PR DESCRIPTION
Closes #33 

Adds a workflow to prune issues and pull requests marked as
"won't fix" (via the label `state:wont-fix`).

The workflow is scheduled to run every hour. The minimum event
schedule granularity for GitHub is every 5 minutes.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>