### PR TITLE
Add support for the mu_feature_dfci repo

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -109,6 +109,7 @@ group:
       template: true
     repos: |
       microsoft/mu_common_intel_min_platform
+      microsoft/mu_feature_dfci
       microsoft/mu_plus
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
@@ -137,6 +138,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample
@@ -180,6 +182,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -205,6 +208,7 @@ group:
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -227,6 +231,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -246,6 +251,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample
@@ -285,6 +291,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -307,6 +314,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -329,6 +337,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -355,6 +364,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -377,6 +387,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -398,6 +409,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -440,6 +452,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -459,6 +472,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -478,6 +492,7 @@ group:
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample

--- a/Notebooks/MyPullRequests.github-issues
+++ b/Notebooks/MyPullRequests.github-issues
@@ -7,7 +7,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
   },
   {
     "kind": 1,

--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -7,7 +7,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_plus repo:microsoft/mu_tiano_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_tiano_platforms repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_feature_ipmi repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_python_library repo:microsoft/mu_pip_build repo:microsoft/mu_build repo:microsoft/mu_common_intel_adv_features"
+    "value": "// list of project mu repos\r\n$repos=repo:repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_plus repo:microsoft/mu_tiano_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_tiano_platforms repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_feature_ipmi repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_python_library repo:microsoft/mu_pip_build repo:microsoft/mu_build repo:microsoft/mu_common_intel_adv_features"
   },
   {
     "kind": 1,

--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -7,7 +7,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_siicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release"
   },
   {
     "kind": 1,


### PR DESCRIPTION
Closes #94 

1. Syncs files to https://github.com/microsoft/mu_feature_dfci
2. Adds issues and pull requests in mu_feature_dfci to the GitHub
   issues notebooks

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>