### PR TITLE
Dependabot and FileSyncer: Run after hours

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -10,12 +10,10 @@
 name: Sync Mu DevOps Files to Mu Repos
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/FileSyncer.yml'
-      - '.sync/**'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run daily at 9am UTC - https://crontab.guru/#0_9_*_*_*
+    - cron: '0 9 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -29,6 +29,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      timezone: "America/Los_Angeles"
+      time: "06:00"
     commit-message:
       prefix: "GitHub Action"
     labels:
@@ -38,6 +40,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      timezone: "America/Los_Angeles"
+      time: "23:00"
     labels:
       - "type:submodules"
       - "type:dependencies"
@@ -46,6 +50,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      timezone: "America/Los_Angeles"
+      time: "01:00"
     commit-message:
       prefix: "pip"
     labels:

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -28,6 +28,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      timezone: "America/Los_Angeles"
+      time: "06:00"
     commit-message:
       prefix: "GitHub Action"
     labels:
@@ -37,6 +39,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      timezone: "America/Los_Angeles"
+      time: "01:00"
     commit-message:
       prefix: "pip"
     labels:


### PR DESCRIPTION
Closes #100 

File sync can cause a large impact on CI resources. This change moves
the trigger to a schedule outside office hours (1AM Pacific Time /
9AM UTC daily) to reduce resource usage during most active periods
of other development.

Schedules dependabot checks for times outside normal Pacific
timezone working hours when most development occurs.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>