### PR TITLE
Update Fedora 35 Build container image to 5b8a008

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -33,4 +33,4 @@
 {% set mu_devops = "v1.4.2" %}
 
 {# The version of the fedora-35-build container to use. #}
-{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-35-build:2113a0e" %}
+{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-35-build:5b8a008" %}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -46,7 +46,7 @@ parameters:
 - name: linux_container_image
   displayName: Linux Container Image
   type: string
-  default: 'ghcr.io/tianocore/containers/fedora-35-build:5800d58'
+  default: 'ghcr.io/tianocore/containers/fedora-35-build:5b8a008'
 - name: packages
   displayName: Packages
   type: string


### PR DESCRIPTION
Includes the changes noted in the following comparison from the prior
container image (`5800d58`):

https://github.com/tianocore/containers/compare/5800d58..5b8a008

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>