### PR TITLE
.sync/azure_pipelines: Enable ci_setup in feature repos

### DIFF
--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     extra_steps:
     - script: sudo microdnf install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux

--- a/.sync/azure_pipelines/custom/mu_feature_config/Windows-VS.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Windows-VS.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     packages: SetupDataPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: $(tool_chain_tag)

--- a/.sync/azure_pipelines/custom/mu_feature_ipmi/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_ipmi/Ubuntu-GCC5.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     packages: IpmiFeaturePkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: $(tool_chain_tag)

--- a/.sync/azure_pipelines/custom/mu_feature_ipmi/Windows-VS.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_ipmi/Windows-VS.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     packages: IpmiFeaturePkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: $(tool_chain_tag)

--- a/.sync/azure_pipelines/custom/mu_feature_mm_supv/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_mm_supv/Ubuntu-GCC5.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     do_pr_eval: false
     packages: MmSupervisorPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/custom/mu_feature_mm_supv/Windows-VS.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_mm_supv/Windows-VS.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     do_ci_build: true
-    do_ci_setup: false
+    do_ci_setup: true
     do_pr_eval: false
     packages: MmSupervisorPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT


### PR DESCRIPTION
Feature repos are being moved to use ci_setup's GetDependencies() instead of external dependencies. Due to this, ci_setup is required.