### PR TITLE
.sync/SECURITY.md: Fix markdownlint errors

### DIFF
--- a/.sync/github_templates/security/SECURITY.md
+++ b/.sync/github_templates/security/SECURITY.md
@@ -6,8 +6,7 @@ code with the intent that any consuming projects can use this code as-is.  If fe
 or fixes are necessary we ask that they contribute them back to the project.  **But**, that
 said, in the firmware ecosystem there is a lot of variation and differentiation, and
 the license in this project allows flexibility for use without contribution back to
-Project Mu. Therefore, any issues found here may or may not exist in products using Project Mu.  
-
+Project Mu. Therefore, any issues found here may or may not exist in products using Project Mu.
 
 ## Supported Versions
 
@@ -19,7 +18,7 @@ For a serious vulnerability we may patch older release branches.
 Project Mu contains code that is available and/or originally authored in other
 repositories (see <https://github.com/tianocore/edk2> as one such example).  For any
 vulnerability found, we may be subject to their security policy and may need to work
-with those groups to resolve amicably and patch the "upstream".  This might involve 
+with those groups to resolve amicably and patch the "upstream".  This might involve
 additional time to release and/or additional confidentiality requirements.
 
 ## Reporting a Vulnerability
@@ -30,7 +29,6 @@ Instead please use **Github Private vulnerability reporting**, which is enabled 
 repository. This process is well documented by github in their documentation [here](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
 
 This process will allow us to privately discuss the issue, collaborate on a solution, and then disclose the vulnerability.
-
 
 ## Preferred Languages
 


### PR DESCRIPTION
The following errors were raised in https://github.com/microsoft/mu
and resolved in this change:

- SECURITY.md:11 MD012/no-multiple-blanks Multiple consecutive blank lines
  [Expected: 1; Actual: 2]
- SECURITY.md:22:84 MD009/no-trailing-spaces Trailing spaces
  [Expected: 0 or 2; Actual: 1]
- SECURITY.md:34 MD012/no-multiple-blanks Multiple consecutive blank lines
  [Expected: 1; Actual: 2]

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>