### PR TITLE
.sync/Files.yml: Sync release drafter config file

### DIFF
--- a/.github/release-draft-config.yml
+++ b/.github/release-draft-config.yml
@@ -5,6 +5,12 @@
 # NOTE: `semver:major`, `semver:minor`, and `semver:patch` can be used to force that
 #       version to roll regardless of other labels.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -10,7 +10,7 @@
 # workflow makes sense in their repo.
 #
 # The release draft configuration is defined in:
-#   - .github/ReleaseDraft.yml
+#   - .github/release-draft-config.yml
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -34,6 +34,6 @@ jobs:
         uses: release-drafter/release-drafter@v5.22.0
         with:
           # Note: Path is relative to .github/
-          config-name: ReleaseDraft.yml
+          config-name: release-draft-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -28,3 +28,4 @@ on:
 jobs:
   draft:
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v1.7.4
+    secrets: inherit

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -452,13 +452,16 @@ group:
       microsoft/mu_devops
 
 # Leaf Workflow - Release Draft
+# Note: The branch name used to draft releases on in this group is
+#       set to the value "main"
   - files:
     - source: .sync/workflows/leaf/release-draft.yml
       dest: .github/workflows/release-draft.yml
       template:
         trigger_branch_name: 'main'
+    - source: .sync/workflows/config/release-draft/release-draft-config.yml
+      dest: .github/release-draft-config.yml
     repos: |
-      microsoft/mu_crypto_release
       microsoft/mu_devops
       microsoft/mu_feature_config
       microsoft/mu_feature_dfci
@@ -466,6 +469,18 @@ group:
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
       microsoft/mu_tiano_platforms
+
+# Leaf Workflow - Release Draft
+# Note: The default branch name used to draft releases on in this group is
+#       the latest Mu release branch (e.g. "release/202208")
+  - files:
+    - source: .sync/workflows/leaf/release-draft.yml
+      dest: .github/workflows/release-draft.yml
+      template: true
+    - source: .sync/workflows/config/release-draft/release-draft-config.yml
+      dest: .github/release-draft-config.yml
+    repos: |
+      microsoft/mu_crypto_release
 
 # Leaf Workflow - Scheduled Maintenance
 # Note: This currently sync to the same repos as the label sync since it is exclusively

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -32,5 +32,8 @@
 {# The git ref value that files dependent on this repo will use. #}
 {% set mu_devops = "v1.7.4" %}
 
+{# The latest Project Mu release branch value. #}
+{% set latest_mu_release_branch = "release/202208" %}
+
 {# The version of the fedora-35-build container to use. #}
 {% set linux_build_container = "ghcr.io/tianocore/containers/fedora-35-build:5b8a008" %}

--- a/.sync/workflows/config/release-draft/release-draft-config.yml
+++ b/.sync/workflows/config/release-draft/release-draft-config.yml
@@ -1,0 +1,93 @@
+# Defines the configuration used for drafting new releases.
+#
+# IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
+#
+# NOTE: `semver:major`, `semver:minor`, and `semver:patch` can be used to force that
+#       version to roll regardless of other labels.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/release-drafter/release-drafter
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: '🚀 Features & ✨ Enhancements'
+    labels:
+      - 'type:design-change'
+      - 'type:enhancement'
+      - 'type:feature-request'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type:bug'
+  - title: '🔐 Security Impacting'
+    labels:
+      - 'impact:security'
+  - title: '📖 Documentation Updates'
+    labels:
+      - 'type:documentation'
+  - title: '🛠️ Submodule Updates'
+    labels:
+      - 'type:submodules'
+
+change-template: >-
+  <ul>
+    <li>
+      $TITLE @$AUTHOR (#$NUMBER)
+      <br>
+      <details>
+        <summary>Change Details</summary>
+        <blockquote>
+          <!-- Non-breaking space to have content if body is empty -->
+          &nbsp; $BODY
+        </blockquote>
+        <hr>
+      </details>
+    </li>
+  </ul>
+
+change-title-escapes: '\<*_&@' # Note: @ is added to disable mentions
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+version-resolver:
+  major:
+    labels:
+      - 'impact:breaking-change'
+      - 'semver:major'
+  minor:
+    labels:
+      - 'semver:minor'
+      - 'type:design-change'
+      - 'type:enhancement'
+      - 'type:feature-request'
+  patch:
+    labels:
+      - 'impact:non-functional'
+      - 'semver:patch'
+      - 'type:bug'
+      - 'type:documentation'
+  default: patch
+
+exclude-labels:
+  - 'type:file-sync'
+  - 'type:notes'
+  - 'type:question'
+
+exclude-contributors:
+  - 'uefibot'

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -25,8 +25,9 @@ name: Update Release Draft
 on:
   push:
     branches:
-      - {{ trigger_branch_name }}
+      - {{ trigger_branch_name if trigger_branch_name else sync_version.latest_mu_release_branch }}
 
 jobs:
   draft:
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@{{ sync_version.mu_devops }}
+    secrets: inherit

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -149,10 +149,12 @@ To see more about this flow look in these files:
 - The main reusable workflow file:
   - .github/workflows/ReleaseDrafter.yml
 - The configuration file for the reusable workflow:
-  - .github/ReleaseDraft.yml
+  - .sync/workflows/config/release-draft/release-draft-config.yml
+    - This will be synced to .github/release-draft-config.yml in repos using release drafter
 
-A Project Mu repo simply needs to sync `.sync/workflows/leaf/release-draft.yml` to their repo and adjust any parameters
-needed in the sync process (like repo default branch name) and the release draft workflow will run in the repo.
+A Project Mu repo simply needs to sync `.sync/workflows/leaf/release-draft.yml` and the config file
+`.sync/workflows/config/release-draft/release-draft-config.yml` to their repo and adjust any parameters needed in the
+sync process (like repo default branch name) and the release draft workflow will run in the repo.
 
 Initial Issue Triage
 --------------------


### PR DESCRIPTION
Fixes #108

Commit 6e00a3d added file sync for the release drafter flow to
Project Mu platform and feature repos. However, the config file
used by the workflow must be local to the repo, so it needs to
be synced as well.

This change syncs the config file.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>