### PR TITLE
Revert "GitHub Action: Bump github/issue-labeler from 2.5 to 2.6 (#98)"

### DIFF
--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
 
       - name: Apply Labels Based on PR Messages
-        uses: github/issue-labeler@v2.6
+        uses: github/issue-labeler@v2.5
         with:
           configuration-path: .github/workflows/label-issues/regex-pull-requests.yml
           enable-versioned-regex: 0


### PR DESCRIPTION
Reverts commit 6678c19

This update is causing failures to be returned from the action
due to attempting to remove labels that do not exist.

Make an update plan separately and update in the future.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>