### PR TITLE
Re-introduce workaround to fix ADO path names for PR eval

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -78,11 +78,16 @@ steps:
 - bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"
 
 # trim the package list if this is a PR
+- powershell:
+    $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
+    Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
+  displayName: Workaround for Branch Names
+  condition: eq(variables['Build.Reason'], 'PullRequest')
 - task: CmdLine@1
   displayName: Check if ${{ parameters.build_pkg }} Needs Testing
   inputs:
     filename: stuart_pr_eval
-    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
+    arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target $(pr_compare_branch) --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
  # Setup repo

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -87,12 +87,17 @@ steps:
 
 # Trim the package list if this is a PR
 - ${{ if eq(parameters.do_pr_eval, true) }}:
+  - powershell:
+      $TargetBranch = "$(System.PullRequest.targetBranch)".replace('refs/heads/', '');
+      Write-Host "##vso[task.setvariable variable=pr_compare_branch]origin/$TargetBranch";
+    displayName: Workaround for Branch Names
+    condition: eq(variables['Build.Reason'], 'PullRequest')
   - task: CmdLine@1
     displayName: Check if ${{ parameters.build_pkgs }} Needs Testing
     inputs:
       filename: stuart_pr_eval
       # Workaround an azure pipelines bug.
-      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target origin/$(System.PullRequest.targetBranch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
+      arguments: -c ${{ parameters.build_file }} -p ${{ parameters.build_pkgs }} --pr-target $(pr_compare_branch) --output-csv-format-string "##vso[task.setvariable variable=pkgs_to_build]{pkgcsv}" --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
     condition: eq(variables['Build.Reason'], 'PullRequest')
 
 - ${{ if eq(parameters.install_tools, true) }}:


### PR DESCRIPTION
Adds a work-around to the naming provided by System.PullRequest.targetBranch on ADO repos by stripping the refs/heads/ from the path since that makes it unrecognizable to git for the git diff used by stuart_pr_eval.