### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v2.0.1

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,5 +27,5 @@ on:
 
 jobs:
   draft:
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v1.7.4
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v2.0.1
     secrets: inherit

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v1.7.4" %}
+{% set mu_devops = "v2.0.1" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202208" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v1.7.4...v2.0.1

General release Info: https://github.com/microsoft/mu_devops/releases

An important change in this release is reverting the label workflow
from v2.6 to v2.5 to resolve a regression:

  https://github.com/microsoft/mu_devops/pull/110

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>