### PR TITLE
.sync/azure_pipelines: Switch from microdnf to dnf

### DIFF
--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -32,7 +32,7 @@ jobs:
     do_ci_build: true
     do_ci_setup: true
     extra_steps:
-    - script: sudo microdnf install --assumeyes mingw64-gcc
+    - script: sudo dnf install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux
     packages: SetupDataPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
@@ -33,7 +33,7 @@ jobs:
     do_ci_setup: true
     do_non_ci_setup: true
     extra_steps:
-    - script: sudo microdnf install --assumeyes mingw64-gcc
+    - script: sudo dnf install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux
     packages: OemPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -38,7 +38,7 @@ jobs:
     extra_build_args: CODE_COVERAGE=TRUE CC_HTML=TRUE
     extra_install_step:
     - script: |
-              sudo microdnf install --assumeyes mingw64-gcc lcov
+              sudo dnf install --assumeyes mingw64-gcc lcov
               pip install lcov_cobertura pycobertura
       displayName: Install Windows Resource Compiler for Linux & Code Coverage Tools
     tool_chain_tag: $(tool_chain_tag)


### PR DESCRIPTION
The following commit in tianocore/containers switched from `microdnf`
to `dnf` since `microdnf` is no longer available in the Fedora 35
minimal base image.

https://github.com/tianocore/containers/commit/3487a34

Therefore, `microdnf` will currently fail (not found). This change
updates code using the Fedora 35 container image to switch to `dnf`.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>