### PR TITLE
PullRequests.github-issues: Remove uefibot and ProjectMuBot from huma…

### DIFF
--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -27,7 +27,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview -author:app/microsoft-github-policy-service"
+    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview -author:app/microsoft-github-policy-service -author:uefibot -author:ProjectMuBot"
   },
   {
     "kind": 1,


### PR DESCRIPTION
PullRequests.github-issues: Remove uefibot and ProjectMuBot from human PRs

Add the bot accounts to those excluded from the "PRs opened by humans"
section in the notebook.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
