### PR TITLE
release-draft-config.yml: Add breaking changes section

### DIFF
--- a/.sync/workflows/config/release-draft/release-draft-config.yml
+++ b/.sync/workflows/config/release-draft/release-draft-config.yml
@@ -28,6 +28,9 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
 categories:
+  - title: '⚠️ Breaking Changes'
+    labels:
+      - 'impact:breaking-change'
   - title: '🚀 Features & ✨ Enhancements'
     labels:
       - 'type:design-change'


### PR DESCRIPTION
Closes #119 

Breaking changes are identified with the GitHub label:
  `impact:breaking-change`

Prior to this change, that label rolled the major version of the
repo.

Now, the label also places corresponding changes into a "Breaking
Changes" section of the release notes so it is easy for consumers
to see breaking changes in a release.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>