### PR TITLE
Remove link to Microsoft security policy for Project Mu repos

### DIFF
--- a/.sync/github_templates/ISSUE_TEMPLATE/config.yml
+++ b/.sync/github_templates/ISSUE_TEMPLATE/config.yml
@@ -14,7 +14,3 @@ contact_links:
   - name: 📃 Project Mu Documentation
     url: https://microsoft.github.io/mu/
     about: Goals, principles, repo layout, build instructions, and more.
-
-  - name: 🔐 Security Reporting Policy
-    url: https://github.com/microsoft/.github/blob/main/SECURITY.md
-    about: A special process is used to report security vulnerabilities.


### PR DESCRIPTION
In the "new" issues menu there was a link for Microsoft's Security Policy.   This is no longer accurate and now each repo has been updated with a valid SECURITY.MD file.