### PR TITLE
.sync/dependabot: Do not update microsoft/mu_devops in Actions updates

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -11,6 +11,9 @@
 #         - Git Submodules (`gitsubmodule`)
 #         - Python PIP Modules (`pip`)
 #
+#       Dependabot does not update the microsoft/mu_devops version because that is updated once in mu_devops
+#       and then synced to all repos when the file sync occurs.
+#
 # - Mu DevOps Repo: https://github.com/microsoft/mu_devops
 # - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
 #
@@ -31,6 +34,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
+    ignore:
+      - dependency-name: "microsoft/mu_devops"
     commit-message:
       prefix: "GitHub Action"
     labels:

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -10,6 +10,9 @@
 #         - GitHub Actions (`github-actions`)
 #         - Python PIP Modules (`pip`)
 #
+#       Dependabot does not update the microsoft/mu_devops version because that is updated once in mu_devops
+#       and then synced to all repos when the file sync occurs.
+#
 # - Mu DevOps Repo: https://github.com/microsoft/mu_devops
 # - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
 #
@@ -30,6 +33,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
+    ignore:
+      - dependency-name: "microsoft/mu_devops"
     commit-message:
       prefix: "GitHub Action"
     labels:


### PR DESCRIPTION
The version is centrally managed in mu_devops and pushed to other
repos in file syncs. Therefore, dependabot does not need to manage
the version independently in respective repos.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
