### PR TITLE
.sync: Add main branch as a trigger to CodeQL workflow

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -24,9 +24,11 @@ name: "CodeQL"
 on:
   push:
     branches:
+      - main
       - release/*
   pull_request_target:
     branches:
+      - main
       - release/*
     paths-ignore:
       - '!**.c'


### PR DESCRIPTION
Some repos that use the workflow have a `main` branch instead of a
`release` branch as their primary branch.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>