### PR TITLE
.sync/release-draft-config.yml: Exclude dependabot contributions

### DIFF
--- a/.sync/workflows/config/release-draft/release-draft-config.yml
+++ b/.sync/workflows/config/release-draft/release-draft-config.yml
@@ -94,3 +94,5 @@ exclude-labels:
 
 exclude-contributors:
   - 'uefibot'
+  - 'dependabot'
+  - 'dependabot[bot]'


### PR DESCRIPTION
Dependabot is noisier now than it used to be, exclude it from release
notes to focus on important changes.