### PR TITLE
.sync/codeql.yml: Use Git long paths on Windows

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -96,6 +96,12 @@ jobs:
       with:
         python-version: '>=3.11'
 
+    - name: Use Git Long Paths on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        git config --system core.longpaths true
+
     - name: Install/Upgrade pip Modules
       run: pip install -r pip-requirements.txt --upgrade
 


### PR DESCRIPTION
It is a well known limitation that GitHub uses the pattern
`<install_dir>/_work/<repo_name>/<repo_name>/` as the working
directory on the GitHub workflow agents.

It is redundant and particularly impactful on Windows as discussed
below:

https://github.com/msysgit/msysgit/wiki/Git-cannot-create-a-file-or-directory-with-a-long-path

This especially causes an issue in a Mu repository at the moment
(`mu_common_intel_min_platform`) due to its longer name which is
repeated twice in the path (as `<repo-name>`).

This change is limited to the GitHub CodeQL workflow and was found
to resolve the issue encountered and not raise any additional issues
in this workflow in testing.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>