### PR TITLE
Create code coverage post-processing steps and integrate into PR Jobs

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -35,5 +35,5 @@
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202208" %}
 
-{# The version of the fedora-35-build container to use. #}
+{# The version of the fedora-37-build container to use. #}
 {% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:f1c7a20" %}

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -36,4 +36,4 @@
 {% set latest_mu_release_branch = "release/202208" %}
 
 {# The version of the fedora-35-build container to use. #}
-{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:14d2aba" %}
+{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:f1c7a20" %}

--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -39,6 +39,7 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: true
+    linux_container_image: {{ sync_version.linux_build_container }}
 
 - template: Jobs/Python/RunDevTests.yml@mu_devops
   parameters:

--- a/.sync/azure_pipelines/custom/mu_feature_ipmi/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_ipmi/Ubuntu-GCC5.yml
@@ -36,3 +36,4 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: true
+    linux_container_image: {{ sync_version.linux_build_container }}

--- a/.sync/azure_pipelines/custom/mu_feature_mm_supv/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_mm_supv/Ubuntu-GCC5.yml
@@ -37,3 +37,4 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: true
+    linux_container_image: {{ sync_version.linux_build_container }}

--- a/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
@@ -40,3 +40,4 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: true
+    linux_container_image: {{ sync_version.linux_build_container }}

--- a/.sync/azure_pipelines/custom/mu_tiano_platforms/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_tiano_platforms/Ubuntu-GCC5.yml
@@ -39,4 +39,5 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: ubuntu-latest
     container_build: true
+    linux_container_image: {{ sync_version.linux_build_container }}
 

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -35,11 +35,11 @@ jobs:
 - template: Matrix-Build-Job.yml
   parameters:
     arch_list: $(arch_list)
-    extra_build_args: CODE_COVERAGE=TRUE CC_HTML=TRUE
+    extra_build_args: CODE_COVERAGE=TRUE
     extra_install_step:
     - script: |
               sudo dnf install --assumeyes mingw64-gcc lcov
-              pip install lcov_cobertura pycobertura
+              pip install lcov_cobertura
       displayName: Install Windows Resource Compiler for Linux & Code Coverage Tools
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -38,8 +38,7 @@ jobs:
     extra_build_args: CODE_COVERAGE=TRUE
     extra_install_step:
     - script: |
-              sudo dnf install --assumeyes mingw64-gcc lcov
-              pip install lcov_cobertura
+              sudo dnf install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux & Code Coverage Tools
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -39,7 +39,7 @@ jobs:
     extra_install_step:
     - script: |
               sudo dnf install --assumeyes mingw64-gcc
-      displayName: Install Windows Resource Compiler for Linux & Code Coverage Tools
+      displayName: Install Windows Resource Compiler for Linux
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_image: linux-gcc

--- a/.sync/azure_pipelines/matrix_dependent/Windows-VS.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Windows-VS.yml
@@ -32,5 +32,6 @@ jobs:
 - template: Matrix-Build-Job.yml
   parameters:
     arch_list: $(arch_list)
+    extra_build_args: CODE_COVERAGE=TRUE
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -96,6 +96,10 @@ jobs:
       - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"
         displayName: Add User Local Bin to Path
     - ${{ parameters.extra_steps }}
+    - script: |
+              sudo dnf install --assumeyes lcov
+              pip install lcov_cobertura
+      displayName: Install Code Coverage Tools
     - template: ../Steps/PrGate.yml
       parameters:
         artifacts_identifier: '$(package) $(target)'
@@ -110,3 +114,15 @@ jobs:
         do_pr_eval: ${{ parameters.do_pr_eval }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ not(parameters.container_build) }}
+        extra_build_args: CODE_COVERAGE=TRUE
+
+  - job: PublishCoverage
+    dependsOn: Build
+    workspace:
+      clean: all
+
+    pool:
+      vmImage: 'windows-2022'
+
+    steps:
+      - template: ../Steps/PublishCodeCoverage.yml

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -47,7 +47,7 @@ parameters:
 - name: linux_container_image
   displayName: Linux Container Image
   type: string
-  default: 'ghcr.io/tianocore/containers/fedora-37-build:f1c7a20'
+  default: ''
 - name: packages
   displayName: Packages
   type: string

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -17,6 +17,7 @@ parameters:
   default: ".pytool/CISettings.py"
 - name: container_build
   displayName: Use Container for Build
+  type: boolean
   default: false
 - name: do_ci_build
   displayName: Perform Stuart CI Build

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -46,7 +46,7 @@ parameters:
 - name: linux_container_image
   displayName: Linux Container Image
   type: string
-  default: 'ghcr.io/tianocore/containers/fedora-35-build:5b8a008'
+  default: 'ghcr.io/tianocore/containers/fedora-37-build:f1c7a20'
 - name: packages
   displayName: Packages
   type: string
@@ -96,10 +96,6 @@ jobs:
       - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"
         displayName: Add User Local Bin to Path
     - ${{ parameters.extra_steps }}
-    - script: |
-              sudo dnf install --assumeyes lcov
-              pip install lcov_cobertura
-      displayName: Install Code Coverage Tools
     - template: ../Steps/PrGate.yml
       parameters:
         artifacts_identifier: '$(package) $(target)'

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -119,7 +119,7 @@ jobs:
       clean: all
 
     pool:
-      vmImage: 'windows-2022'
+      vmImage: 'windows-latest'
 
     steps:
       - template: ../Steps/PublishCodeCoverage.yml

--- a/Steps/CommonLogCopyAndPublish.yml
+++ b/Steps/CommonLogCopyAndPublish.yml
@@ -22,9 +22,9 @@ steps:
       **/BUILD_REPORT.TXT
       **/BUILD_TOOLS_REPORT.html
       **/BUILD_TOOLS_REPORT.json
+      **/*coverage.xml
       **/FD_REPORT.HTML
       **/OVERRIDELOG.TXT
-      **/*coverage.xml
       BASETOOLS_BUILD*.*
       BUILDLOG_*.md
       BUILDLOG_*.txt

--- a/Steps/CommonLogCopyAndPublish.yml
+++ b/Steps/CommonLogCopyAndPublish.yml
@@ -19,10 +19,10 @@ steps:
     targetFolder: "$(Build.ArtifactStagingDirectory)/Logs"
     SourceFolder: "Build"
     contents: |
+      **/*coverage.xml
       **/BUILD_REPORT.TXT
       **/BUILD_TOOLS_REPORT.html
       **/BUILD_TOOLS_REPORT.json
-      **/*coverage.xml
       **/FD_REPORT.HTML
       **/OVERRIDELOG.TXT
       BASETOOLS_BUILD*.*

--- a/Steps/CommonLogCopyAndPublish.yml
+++ b/Steps/CommonLogCopyAndPublish.yml
@@ -24,14 +24,13 @@ steps:
       **/BUILD_TOOLS_REPORT.json
       **/FD_REPORT.HTML
       **/OVERRIDELOG.TXT
+      **/*coverage.xml
       BASETOOLS_BUILD*.*
       BUILDLOG_*.md
       BUILDLOG_*.txt
       CI_*.md
       CI_*.txt
       CISETUP.txt
-      coverage.html
-      coverage.xml
       PREVALLOG.txt
       SETUPLOG.txt
       TestSuites.xml

--- a/Steps/InstallCoverageTools.yml
+++ b/Steps/InstallCoverageTools.yml
@@ -1,0 +1,12 @@
+## @file
+# Azure Pipelines step template to install code coverage tools.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- powershell: choco install opencppcoverage; Write-Host "##vso[task.prependpath]C:\Program Files\OpenCppCoverage"
+  displayName: Install Windows Code Coverage Tools
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )

--- a/Steps/InstallCoverageTools.yml
+++ b/Steps/InstallCoverageTools.yml
@@ -7,6 +7,8 @@
 
 steps:
 
-- powershell: choco install opencppcoverage; Write-Host "##vso[task.prependpath]C:\Program Files\OpenCppCoverage"
+- powershell: |
+    choco install opencppcoverage
+    Write-Host "##vso[task.prependpath]C:\Program Files\OpenCppCoverage"
   displayName: Install Windows Code Coverage Tools
   condition: eq( variables['Agent.OS'], 'Windows_NT' )

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -189,11 +189,3 @@ steps:
   parameters:
     artifacts_other: ${{ parameters.artifacts_other }}
     artifacts_identifier: ${{ parameters.artifacts_identifier }}
-
-- task: PublishCodeCoverageResults@1
-  displayName: Publish Code Coverage Results
-  inputs:
-    codeCoverageTool: 'Cobertura'
-    summaryFileLocation: 'Build/coverage.xml'
-    pathToSources: '$(Build.SourcesDirectory)'
-  condition: and(succeededOrFailed(), and(gt(variables.pkg_count, 0), contains('${{ parameters.extra_build_args }}', 'CODE_COVERAGE=TRUE')))

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -106,6 +106,9 @@ steps:
 - ${{ if eq(parameters.install_tools, true) }}:
   - template: InstallMarkdownLint.yml
 
+- ${{ if eq(parameters.install_tools, true) }}:
+  - template: InstallCoverageTools.yml
+
 # Build repo
 - ${{ if eq(parameters.do_ci_setup, true) }}:
   - task: CmdLine@1

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -29,14 +29,14 @@ steps:
   inputs:
     buildType: 'current'
     targetPath: '$(Build.ArtifactStagingDirectory)/coverage/'
-    itemPattern: "**/coverage.xml"
+    itemPattern: "**/*coverage.xml"
 
 - task: CmdLine@2
   displayName: Create code coverage report
   inputs:
     script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool
-      reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura -filefilters:-*MU*;-*Build*;-*UnitTest*;-*Mock*;-*usr*
+      reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/*coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage'

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -1,0 +1,45 @@
+## @file
+# Azure Pipelines step template to merge and publish all code coverage results.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: include_paths
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+- name: exclude_paths
+  displayName: Tool Chain (e.g. VS2022)
+  type: string
+  default: ''
+
+steps:
+- checkout: self
+  clean: true
+  fetchDepth: 1
+
+#
+# Download the build
+#
+- task: DownloadPipelineArtifact@2
+  name: DownloadBuildLogArtifacts
+  displayName: Download Log Artifacts
+  inputs:
+    buildType: 'current'
+    targetPath: '$(Build.ArtifactStagingDirectory)/coverage/'
+    itemPattern: "**/coverage.xml"
+
+- task: CmdLine@2
+  displayName: Create code coverage report
+  inputs:
+    script: |
+      dotnet tool install -g dotnet-reportgenerator-globaltool
+      reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura -filefilters:-*MU*;-*Build*;-*UnitTest*;-*Mock*;-*usr*
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml'

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -21,15 +21,22 @@ steps:
     targetPath: '$(Build.ArtifactStagingDirectory)/coverage/'
     itemPattern: "**/*coverage.xml"
 
+- powershell: |
+    $coverage_file_count=(Get-ChildItem $(Build.ArtifactStagingDirectory)/coverage/ -Recurse -Include *coverage.xml).count
+    Write-Host echo "##vso[task.setvariable variable=coverage_file_count]$coverage_file_count"
+  displayName: Check For Coverage Files
+
 - task: CmdLine@2
-  displayName: Create code coverage report
+  displayName: Create Coverage Report
   inputs:
     script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool
       reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/*coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura
+  condition: gt(variables.coverage_file_count, 0)
 
 - task: PublishCodeCoverageResults@1
-  displayName: 'Publish code coverage'
+  displayName: Publish Code Coverage
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml'
+  condition: gt(variables.coverage_file_count, 0)

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -5,16 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
-parameters:
-- name: include_paths
-  displayName: Tool Chain (e.g. VS2022)
-  type: string
-  default: ''
-- name: exclude_paths
-  displayName: Tool Chain (e.g. VS2022)
-  type: string
-  default: ''
-
 steps:
 - checkout: self
   clean: true


### PR DESCRIPTION
1. Switch to coverage files per-matrix to not publish coverage
2. Add steps to download and merge/filter all artifacts
3. Integrates steps into job templates.

Issue #84 