### PR TITLE
.sync/Files.yml: Sync CodeQL workflow to additional repos

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -376,9 +376,13 @@ group:
     repos: |
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
+      microsoft/mu_feature_config
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
+      microsoft/mu_oem_sample
       microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_plus
 


### PR DESCRIPTION
Syncs the CodeQL leaf workflow to the following additional repos:

- microsoft/mu_feature_config
- microsoft/mu_feature_ipmi
- microsoft/mu_oem_sample
- microsoft/mu_silicon_arm_tiano

The workflow is now synced to all Mu repos with large amounts of
C code except mu_tiano_platforms. That will be included in a
future change.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>