### PR TITLE
.sync/Files.yml: Remove CodeQL workflow from mu_silicon_arm_tiano

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -382,7 +382,9 @@ group:
       microsoft/mu_feature_mm_supv
       microsoft/mu_oem_sample
       microsoft/mu_plus
-      microsoft/mu_silicon_arm_tiano
+      # Note: Lack of Visual Studio support is currently a blocker for
+      #       enabling the CodeQL workflow as-is in mu_silicon_arm_tiano.
+      # microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_plus
 


### PR DESCRIPTION
The workflow currently builds on Visual Studio due to a CodeQL
extractor bug. ARM packages only build on GCC in CI right now.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>