### PR TITLE
.sync/Files.yml: Move CodeQL workflow comment

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -370,6 +370,9 @@ group:
       microsoft/mu_tiano_plus
 
 # Leaf Workflow - CodeQL
+# Note: Lack of Visual Studio support is currently a blocker for
+#       enabling the CodeQL workflow as-is in mu_silicon_arm_tiano.
+#       # microsoft/mu_silicon_arm_tiano
   - files:
     - source: .sync/workflows/leaf/codeql.yml
       dest: .github/workflows/codeql.yml
@@ -382,9 +385,6 @@ group:
       microsoft/mu_feature_mm_supv
       microsoft/mu_oem_sample
       microsoft/mu_plus
-      # Note: Lack of Visual Studio support is currently a blocker for
-      #       enabling the CodeQL workflow as-is in mu_silicon_arm_tiano.
-      # microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_plus
 


### PR DESCRIPTION
Move out of the `repos` list and append onto the preceding group
description.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>