### PR TITLE
.sync/Version.njk: Update Linux build container to Fedora 37 image

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -36,4 +36,4 @@
 {% set latest_mu_release_branch = "release/202208" %}
 
 {# The version of the fedora-35-build container to use. #}
-{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-35-build:5b8a008" %}
+{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:14d2aba" %}

--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/tianocore/containers/fedora-35-dev:latest",
+  "image": "ghcr.io/tianocore/containers/fedora-37-dev:latest",
   "postCreateCommand": "git config --global --add safe.directory * && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Updates the Linux build container from Fedora 35 to Fedora 37 image.

Closes #145

[14d2aba image](https://github.com/tianocore/containers/pkgs/container/containers%2Ffedora-37-build/75760493?tag=14d2aba)

- [Fedora 35 image contents](https://github.com/tianocore/containers/blob/main/Fedora-35/Readme.md)
- [Fedora 37 image contents](https://github.com/tianocore/containers/blob/main/Fedora-37/Readme.md)

Summary of updates:

- Fedora 35 to Fedora 37 (minimal image)
  - NEW: gcc for LoongArch (2022-09-06)
  - UPDATED: gcc 11.2.1 to gcc 12.2 (x86, x64, arm, aarch64, riscv)
  - UPDATED: Python 3.10 to Python 3.11
  - UPDATED: Qemu 6.10 to Qemu 7.2 (x86, arm, aarch64)
  - NO CHANGE: nasm 2.15.05