### PR TITLE
Add variable to prevent checkout step, for pipelines that need it

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -62,13 +62,17 @@ parameters:
   displayName: Tool Chain (e.g. VS2022)
   type: string
   default: ''
+- name: checkout_self
+  displayName: Install Build Tools
+  type: boolean
+  default: true
 
 steps:
-
-- checkout: self
-  clean: true
-  # Note: Depth cannot be limited if PR Eval is used. A pipeline may choose
-  #       to use a shallow checkout if PR eval is not used.
+- ${{ if eq(parameters.checkout_self, true) }}:
+  - checkout: self
+    clean: true
+    # Note: Depth cannot be limited if PR Eval is used. A pipeline may choose
+    #       to use a shallow checkout if PR eval is not used.
 
 - template: SetupPythonPreReqs.yml
   parameters:

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -63,7 +63,7 @@ parameters:
   type: string
   default: ''
 - name: checkout_self
-  displayName: Install Build Tools
+  displayName: Perform self checkout step
   type: boolean
   default: true
 

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -71,7 +71,7 @@ parameters:
   type: string
   default: ''
 - name: checkout_self
-  displayName: Install Build Tools
+  displayName: Perform self checkout step
   type: boolean
   default: true
 

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -70,11 +70,16 @@ parameters:
   displayName: Tool Chain (e.g. VS2022)
   type: string
   default: ''
+- name: checkout_self
+  displayName: Install Build Tools
+  type: boolean
+  default: true
 
 steps:
-- checkout: self
-  clean: true
-  # Note: Depth cannot be limited if PR Eval is used
+- ${{ if eq(parameters.checkout_self, true) }}:
+  - checkout: self
+    clean: true
+    # Note: Depth cannot be limited if PR Eval is used
 
 - template: SetupPythonPreReqs.yml
   parameters:


### PR DESCRIPTION
Some containers may have performed the checkout step earlier, either for code scanning or for other reasons.

Proposal to add a variable to prevent the checkout step for those repos /containers that have already taken the step. 