### PR TITLE
.sync/workflows/codeql.yml: Add PIP module caching

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -49,6 +49,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '>=3.11'
+        cache: 'pip'
+        cache-dependency-path: 'pip-requirements.txt'
 
     - name: Generate Package Matrix
       id: generate_matrix
@@ -95,6 +97,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '>=3.11'
+        cache: 'pip'
+        cache-dependency-path: 'pip-requirements.txt'
 
     - name: Use Git Long Paths on Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
Adds caching of PIP dependencies. This reduces overall execution time
and decreases likelihood of a network error reaching out pypi to get
the dependencies.

Caching happens automatically based on pip-requirements.txt.

https://github.com/actions/setup-python#caching-packages-dependencies

Every job before:

```
Run pip install -r pip-requirements.txt --upgrade
Collecting edk2-pytool-library==0.14.0
  Downloading edk2_pytool_library-0.14.0-py3-none-any.whl (468 kB)
     -------------------------------------- 468.7/468.7 kB 2.7 MB/s eta 0:00:00
Collecting edk2-pytool-extensions==0.22.2
  Downloading edk2_pytool_extensions-0.22.2-py3-none-any.whl (2.5 MB)
     ---------------------------------------- 2.5/2.5 MB 10.7 MB/s eta 0:00:00
Collecting edk2-basetools==0.1.29
  Downloading edk2_basetools-0.1.29-py3-none-any.whl (1.3 MB)
     ---------------------------------------- 1.3/1.3 MB 4.5 MB/s eta 0:00:00
Collecting antlr4-python3-runtime==4.12.0
  Downloading antlr4_python3_runtime-4.12.0-py3-none-any.whl (144 kB)
     -------------------------------------- 144.4/144.4 kB 2.2 MB/s eta 0:00:00
Collecting regex==2023.3.23
  Downloading regex-2023.3.23-cp311-cp311-win_amd64.whl (267 kB)
     -------------------------------------- 267.7/267.7 kB 2.4 MB/s eta 0:00:00
...
```

Jobs after:

```
Run pip install -r pip-requirements.txt --upgrade
Collecting edk2-pytool-library==0.14.0
  Using cached edk2_pytool_library-0.14.0-py3-none-any.whl (468 kB)
Collecting edk2-pytool-extensions==0.22.2
  Using cached edk2_pytool_extensions-0.22.2-py3-none-any.whl (2.5 MB)
Collecting edk2-basetools==0.1.29
  Using cached edk2_basetools-0.1.29-py3-none-any.whl (1.3 MB)
Collecting antlr4-python3-runtime==4.12.0
  Using cached antlr4_python3_runtime-4.12.0-py3-none-any.whl (144 kB)
Collecting regex==2023.3.23
  Using cached regex-2023.3.23-cp311-cp311-win_amd64.whl (267 kB)
...
```

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>