### PR TITLE
Jobs/PrGate.yml: Add Linux container option parameter

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -48,6 +48,10 @@ parameters:
   displayName: Linux Container Image
   type: string
   default: ''
+- name: linux_container_options
+  displayName: Linux Container Options
+  type: string
+  default: ''
 - name: packages
   displayName: Packages
   type: string
@@ -89,7 +93,9 @@ jobs:
 
     # Use a container if one was specified.
     ${{ if and(eq(parameters.container_build, true), not(contains(parameters.vm_image, 'windows'))) }}:
-      container: ${{ parameters.linux_container_image }}
+      container:
+        image: ${{ parameters.linux_container_image }}
+        options: ${{ parameters.linux_container_options }}
 
     steps:
     # Add local path to ensure pip install modules are discoverable.


### PR DESCRIPTION
Allows the caller to specify options passed to the Linux container.

See the following article for more information about `options:`. https://learn.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#options