### PR TITLE
codeql.yml: Remove PIP caching from pkg gathering

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -49,8 +49,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '>=3.11'
-        cache: 'pip'
-        cache-dependency-path: 'pip-requirements.txt'
 
     - name: Generate Package Matrix
       id: generate_matrix


### PR DESCRIPTION
PIP modules are not pulled down during the initial job in the CodeQL
workflow (package gathering) so PIP caching is not needed.

Also works around a setup-python task issue that fails to ignore cache
contents if they do not previously exist and are not populated during the job.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>