### PR TITLE
.sync/dependabot: Check for submodule updates weekly

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -44,7 +44,7 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       timezone: "America/Los_Angeles"
       time: "23:00"
     labels:


### PR DESCRIPTION
Reduce frequency of submodule checks from daily to weekly to reduce
CI thrash.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>