### PR TITLE
.sync/Files.yml: Sync release drafter to mu_basecore

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -511,6 +511,7 @@ group:
     - source: .sync/workflows/config/release-draft/release-draft-config.yml
       dest: .github/release-draft-config.yml
     repos: |
+      microsoft/mu_basecore
       microsoft/mu_crypto_release
 
 # Leaf Workflow - Scheduled Maintenance


### PR DESCRIPTION
Syncs the following files to mu_basecore to enable the release
drafter workflow in that repo.

- `release-draft.yml` - Leaf workflow
- `release-draft-config.yml` - Action config file

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>