### PR TITLE
.sync/dependabot: Disable automatic rebasing

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -40,6 +40,7 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
@@ -50,6 +51,7 @@ updates:
     labels:
       - "type:submodules"
       - "type:dependencies"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -62,3 +64,4 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
+    rebase-strategy: "disabled"

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -39,6 +39,7 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -51,3 +52,4 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Sets the rebase-strategy to "disabled" to prevent automatic rebasing.

This prevents CI resources from building changes that may not actually
be merged for a while (and need to be rebuilt later again).

Rebasing can be done manually in the dependabot PR either through
the GitHub UI or the dependabot command or via a push to the
dependabot PR branch.