### PR TITLE
.sync/dependabot: Ignore submodules with versioned releases

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -52,6 +52,9 @@ updates:
       - "type:submodules"
       - "type:dependencies"
     rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "MU_BASECORE"
+      - dependency-name: "Features/DFCI"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Submodules with versioned releases will now be updated with the
Submodule Release Updater action so there is no need for
dependabot to create duplicate PRs for non-release updates of
these submodules.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>