### PR TITLE
.sync/submodule-release-update.yml: Add Nunjucks raw text tags

### DIFF
--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Update Submodules to Latest Release
         uses: microsoft/mu_devops/.github/actions/submodule-release-updater@{{ sync_version.mu_devops }}
         with:
-          GH_PAT: ${{ secrets.SUBMODULE_UPDATER_TOKEN }}
+          GH_PAT: {% raw %}${{ secrets.SUBMODULE_UPDATER_TOKEN }}{% endraw %}
           GH_USER: "ProjectMuBot"
           GIT_EMAIL: "mubot@microsoft.com"
           GIT_NAME: "Project Mu Bot"


### PR DESCRIPTION
Surrounds the GitHub token syntax with raw tags to indicate that
the curly braces should not be interpreted as a Nunjucks expression
or variable and treated as a literal.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>