### PR TITLE
.sync/Version.njk: Update Linux build container to Fedora 37 3b3eb8f

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -36,4 +36,4 @@
 {% set latest_mu_release_branch = "release/202208" %}
 
 {# The version of the fedora-37-build container to use. #}
-{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:f1c7a20" %}
+{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:3b3eb8f" %}


### PR DESCRIPTION
Updates the Fedora 37 build container from f1c7a20 to 3b3eb8f.

- [Fedora 37 image contents](https://github.com/tianocore/containers/blob/main/Fedora-37/Readme.md)
- [3b3eb8f](https://github.com/tianocore/containers/pkgs/container/containers%2Ffedora-37-build/81369123?tag=3b3eb8f)

Summary of updates:

- Enable GTK on Fedora QEMU
- Install vim and nano
- Set up a user to match the outside user
- Add the user to the sudo/wheel group to allow them to use sudo, and set a password

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>