### PR TITLE
Add quotes to git safe.directory in .devcontainer to fix parsing error

### DIFF
--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "ghcr.io/tianocore/containers/fedora-37-dev:latest",
-  "postCreateCommand": "git config --global --add safe.directory * && pip install --upgrade -r pip-requirements.txt",
+  "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
Currently the git command fails because the * is not parsed correctly in command line without the quote. This resolves this issue. 