### PR TITLE
Add Issue Assignment workflow

### DIFF
--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -1,0 +1,51 @@
+# This reusable workflow provides actions that should be applied when an issue is assigned.
+#
+# NOTE: This file uses a reusable workflow. Do not make changes to the file that should be made
+#       in the common/reusable workflow.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: React to Issue Assignment
+
+on:
+  workflow_call:
+
+jobs:
+  adjust-labels:
+    name: Adjust Issue Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Remove Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # All labels here will be removed if present in the issue
+          LABELS_TO_REMOVE=("state:needs-owner")
+
+          # Gather issue context information
+          ISSUE_NUMBER=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
+          OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
+          REPO=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
+          LABELS=$(curl -s \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels | jq -r '.[].name')
+
+          # Remove labels
+          for LABEL in "${LABELS_TO_REMOVE[@]}"; do
+            if echo "$LABELS" | grep -q "$LABEL"; then
+              curl -X DELETE \
+                   -s \
+                   -H "Accept: application/vnd.github+json" \
+                   -H "Authorization: Bearer $GITHUB_TOKEN" \
+                   -H "X-GitHub-Api-Version: 2022-11-28" \
+                   https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/labels/"$LABEL" > /dev/null
+              echo "$LABEL removed from issue #$ISSUE_NUMBER"
+            else
+              echo "$LABEL not found on issue #$ISSUE_NUMBER"
+            fi
+          done

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -379,6 +379,10 @@ group:
       microsoft/mu_tiano_plus
 
 # Leaf Workflow - Issue Triage
+# Leaf Workflow - Issue Assignment
+#                 Note: This workflow is synced with "Issue Triage" because it adjusts
+#                 labels typically applied in the triage process and applies to the
+#                 same set of repositories that support issue labeing.
   - files:
     - source: .sync/workflows/leaf/triage-issues.yml
       dest: .github/workflows/triage-issues.yml
@@ -388,6 +392,9 @@ group:
     #       at `.github/workflows/triage-issues/issue-label-mapping.yml`.
     - source: .sync/workflows/config/triage-issues/advanced-issue-labeler.yml
       dest: .github/advanced-issue-labeler.yml
+    - source: .sync/workflows/leaf/issue-assignment.yml
+      dest: .github/workflows/issue-assignment.yml
+      template: true
     repos: |
       microsoft/mu
       microsoft/mu_basecore

--- a/.sync/workflows/leaf/issue-assignment.yml
+++ b/.sync/workflows/leaf/issue-assignment.yml
@@ -1,0 +1,23 @@
+# This workflow provides actions that should be applied when an issue is assigned.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+{% import '../../Version.njk' as sync_version -%}
+
+name: React to Issue Assignment
+
+on:
+  issues:
+    types: assigned
+
+jobs:
+  apply:
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@{{ sync_version.mu_devops }}

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -172,6 +172,9 @@ workflow will run in the repo.
 
 .. _`GitHub issue form templates`: https://github.com/microsoft/mu_devops/tree/main/.sync/github_templates/ISSUE_TEMPLATE
 
+This workflow works in concert with other issue workflows such as `.sync/workflows/leaf/issue-assignment.yml` to
+automate labels in issues based on the state of the issue.
+
 Auto Merge
 ----------
 


### PR DESCRIPTION
Resolves #166

Adds a new GitHub workflow that runs when an issue is assigned.

While additional behavior can be added in the future, right now the
workflow only removes the `state:needs-owner` label if present.