### PR TITLE
<Binary/Other>CopyAndPublish.yml: Use bash to parse parameter string

### DIFF
--- a/Steps/BinaryCopyAndPublish.yml
+++ b/Steps/BinaryCopyAndPublish.yml
@@ -17,6 +17,14 @@ parameters:
   default: 'Artifacts'
 
 steps:
+- bash: |
+    artifacts_str=$(echo "${{ parameters.artifacts_binary }}" | tr -d '[:space:]')
+    if [[ -z "$artifacts_str" ]]; then
+      echo "##vso[task.setvariable variable=artifacts_present]false"
+    else
+      echo "##vso[task.setvariable variable=artifacts_present]true"
+    fi
+
 # Copy binaries to the artifact staging directory
 - task: CopyFiles@2
   displayName: Copy Build Binaries
@@ -26,7 +34,7 @@ steps:
     contents: |
       ${{ parameters.artifacts_binary }}
     flattenFolders: true
-  condition: and(succeededOrFailed(), ne('${{ parameters.artifacts_binary }}', ''))
+  condition: and(succeededOrFailed(), eq(variables.artifacts_present, 'true'))
 
 # Publish build artifacts to Azure Artifacts/TFS or a file share
 - task: PublishBuildArtifacts@1
@@ -35,4 +43,4 @@ steps:
   inputs:
     pathtoPublish: "$(Build.ArtifactStagingDirectory)/Binaries"
     artifactName: "Binaries ${{ parameters.artifacts_identifier }}"
-  condition: and(succeededOrFailed(), ne('${{ parameters.artifacts_binary }}', ''))
+  condition: and(succeededOrFailed(), eq(variables.artifacts_present, 'true'))

--- a/Steps/OtherCopyAndPublish.yml
+++ b/Steps/OtherCopyAndPublish.yml
@@ -17,6 +17,14 @@ parameters:
   default: ''
 
 steps:
+- bash: |
+    artifacts_str=$(echo "${{ parameters.artifacts_other }}" | tr -d '[:space:]')
+    if [[ -z "$artifacts_str" ]]; then
+      echo "##vso[task.setvariable variable=artifacts_present]false"
+    else
+      echo "##vso[task.setvariable variable=artifacts_present]true"
+    fi
+
 # Copy other files to the artifact staging directory
 - task: CopyFiles@2
   displayName: Copy Other Files from Build
@@ -26,7 +34,7 @@ steps:
     contents: |
       ${{ parameters.artifacts_other }}
     flattenFolders: true
-  condition: and(succeededOrFailed(), ne('${{ parameters.artifacts_other }}', ''))
+  condition: and(succeededOrFailed(), eq(variables.artifacts_present, 'true'))
 
 # Publish build artifacts to Azure Artifacts/TFS or a file share
 - task: PublishBuildArtifacts@1
@@ -35,4 +43,4 @@ steps:
   inputs:
     pathtoPublish: "$(Build.ArtifactStagingDirectory)/Other"
     artifactName: "Other ${{ parameters.artifacts_identifier }}"
-  condition: and(succeededOrFailed(), ne('${{ parameters.artifacts_other }}', ''))
+  condition: and(succeededOrFailed(), eq(variables.artifacts_present, 'true'))


### PR DESCRIPTION
Uses bash to parse a parameter string that could be empty since it
is more robust and consistent than directly depending on pipeline
string interpretation logic.

This treats the following strings as "empty":
- ""
- " "