### PR TITLE
.sync/codeql: Use pull_request trigger type

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -26,7 +26,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release/*


### PR DESCRIPTION
This workflow needs to run against code on the PR merge branch and
since it is just building it only needs minimal, read-only token
permissions so this change updates the trigger type from
`pull_request_target` to `pull_request`.