### PR TITLE
.sync/dependabot: Ignore additional submodules with versioned releases

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -54,7 +54,9 @@ updates:
     rebase-strategy: "disabled"
     ignore:
       - dependency-name: "MU_BASECORE"
+      - dependency-name: "Features/CONFIG"
       - dependency-name: "Features/DFCI"
+      - dependency-name: "Features/MM_SUPV"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
The following repos recently moved to semantic versioning so they
can be updated by their versioned releases now instead of dependabot
checking for the latest commit hash.

- [mu_feature_config](https://github.com/microsoft/mu_feature_config/issues/168)
- [mu_feature_mm_supv](https://github.com/microsoft/mu_feature_mm_supv/issues/110)