### PR TITLE
Add a dependabot label and exclude it from release notes 

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -121,6 +121,10 @@
   description: Something isn't working
   color: 'd73a4a'
   aliases: []
+- name: type:dependabot
+  description: Created by dependabot
+  color: 'c57a90'
+  aliases: []
 - name: type:dependencies
   description: Pull requests that update a dependency file
   color: '0366d6'

--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -40,6 +40,7 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
+      - "type:dependabot"
     rebase-strategy: "disabled"
 
   - package-ecosystem: "gitsubmodule"
@@ -69,4 +70,5 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
+      - "type:dependabot"
     rebase-strategy: "disabled"

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -39,6 +39,7 @@ updates:
       prefix: "GitHub Action"
     labels:
       - "type:dependencies"
+      - "type:dependabot"
     rebase-strategy: "disabled"
 
   - package-ecosystem: "pip"
@@ -52,4 +53,5 @@ updates:
     labels:
       - "language:python"
       - "type:dependencies"
+      - "type:dependabot"
     rebase-strategy: "disabled"

--- a/.sync/workflows/config/release-draft/release-draft-config.yml
+++ b/.sync/workflows/config/release-draft/release-draft-config.yml
@@ -88,11 +88,10 @@ version-resolver:
   default: patch
 
 exclude-labels:
+  - 'type:dependabot'
   - 'type:file-sync'
   - 'type:notes'
   - 'type:question'
 
 exclude-contributors:
   - 'uefibot'
-  - 'dependabot'
-  - 'dependabot[bot]'


### PR DESCRIPTION
The `release-drafter` GitHub action has an `exclude-contributors`
configuration option that excludes usernames from the final
contributors. This does not appear to work for dependabot.

The `exclude-labels` configuration option does work. This change
adds a new label `type:dependabot` to dependabot PRs (via the
dependabot config file) and uses the `exclude-labels` option in
the `release-drafter` config file to exclude those PRs from release
notes.

Submodules are currently updated by either `dependabot` or the
`submodule-release-updater` GitHub action local to mu_devops. Since
submodules are recursive to repo consumers and to keep those
consistently in the release notes, the `type:dependabot` label is
not added to dependabot submodule updates keeping those updates in
the release notes.