### PR TITLE
.sync/Version.njk: Update latest Mu release branch to 202302

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -510,7 +510,7 @@ group:
 
 # Leaf Workflow - Release Draft
 # Note: The default branch name used to draft releases on in this group is
-#       the latest Mu release branch (e.g. "release/202208")
+#       the latest Mu release branch (e.g. "release/202302")
   - files:
     - source: .sync/workflows/leaf/release-draft.yml
       dest: .github/workflows/release-draft.yml

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -33,7 +33,7 @@
 {% set mu_devops = "v2.5.1" %}
 
 {# The latest Project Mu release branch value. #}
-{% set latest_mu_release_branch = "release/202208" %}
+{% set latest_mu_release_branch = "release/202302" %}
 
 {# The version of the fedora-37-build container to use. #}
 {% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:3b3eb8f" %}


### PR DESCRIPTION
Updates the `latest_mu_release_branch` value substituted into sync
templates from `release/202208` to `release/202302`.