### PR TITLE
.sync/Files.yml: Sync release drafter to additional repos

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -519,7 +519,13 @@ group:
       dest: .github/release-draft-config.yml
     repos: |
       microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
+      microsoft/mu_oem_sample
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_plus
 
 # Leaf Workflow - Scheduled Maintenance
 # Note: This currently sync to the same repos as the label sync since it is exclusively


### PR DESCRIPTION
More repos with `release` branches are moving to versioned releases
so the release drafter workflow is synced to them in this change.

New repos:

- microsoft/mu_common_intel_min_platform
- microsoft/mu_oem_sample
- microsoft/mu_plus
- microsoft/mu_silicon_arm_tiano
- microsoft/mu_silicon_intel_tiano
- microsoft/mu_tiano_plus