### PR TITLE
.sync/Version.njk: Switch to Project Mu Ubuntu 22 containers

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -35,5 +35,5 @@
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}
 
-{# The version of the fedora-37-build container to use. #}
-{% set linux_build_container = "ghcr.io/tianocore/containers/fedora-37-build:3b3eb8f" %}
+{# The version of the ubuntu-22-build container to use. #}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:4a1f8d3" %}

--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -31,9 +31,6 @@ jobs:
     arch_list: $(arch_list)
     do_ci_build: true
     do_ci_setup: true
-    extra_steps:
-    - script: sudo apt-get install -y gcc-mingw-w64
-      displayName: Install Windows Resource Compiler for Linux
     packages: SetupDataPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: $(tool_chain_tag)

--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -32,7 +32,7 @@ jobs:
     do_ci_build: true
     do_ci_setup: true
     extra_steps:
-    - script: sudo dnf install --assumeyes mingw64-gcc
+    - script: sudo apt-get install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux
     packages: SetupDataPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_feature_config/Ubuntu-GCC5.yml
@@ -32,7 +32,7 @@ jobs:
     do_ci_build: true
     do_ci_setup: true
     extra_steps:
-    - script: sudo apt-get install --assumeyes mingw64-gcc
+    - script: sudo apt-get install -y gcc-mingw-w64
       displayName: Install Windows Resource Compiler for Linux
     packages: SetupDataPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
@@ -33,7 +33,7 @@ jobs:
     do_ci_setup: true
     do_non_ci_setup: true
     extra_steps:
-    - script: sudo apt-get install --assumeyes mingw64-gcc
+    - script: sudo apt-get install -y gcc-mingw-w64
       displayName: Install Windows Resource Compiler for Linux
     packages: OemPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
@@ -32,9 +32,6 @@ jobs:
     do_ci_build: true
     do_ci_setup: true
     do_non_ci_setup: true
-    extra_steps:
-    - script: sudo apt-get install -y gcc-mingw-w64
-      displayName: Install Windows Resource Compiler for Linux
     packages: OemPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
     tool_chain_tag: $(tool_chain_tag)

--- a/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/custom/mu_oem_sample/Ubuntu-GCC5.yml
@@ -33,7 +33,7 @@ jobs:
     do_ci_setup: true
     do_non_ci_setup: true
     extra_steps:
-    - script: sudo dnf install --assumeyes mingw64-gcc
+    - script: sudo apt-get install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux
     packages: OemPkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -38,7 +38,7 @@ jobs:
     extra_build_args: CODE_COVERAGE=TRUE
     extra_install_step:
     - script: |
-              sudo dnf install --assumeyes mingw64-gcc
+              sudo apt-get install --assumeyes mingw64-gcc
       displayName: Install Windows Resource Compiler for Linux
     tool_chain_tag: 'GCC5'
     vm_image: $(vm_image)

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -36,10 +36,6 @@ jobs:
   parameters:
     arch_list: $(arch_list)
     extra_build_args: CODE_COVERAGE=TRUE
-    extra_install_step:
-    - script: |
-              sudo apt-get install -y gcc-mingw-w64
-      displayName: Install Windows Resource Compiler for Linux
     tool_chain_tag: 'GCC5'
     vm_image: $(vm_image)
     container_image: linux-gcc

--- a/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
+++ b/.sync/azure_pipelines/matrix_dependent/Ubuntu-GCC5.yml
@@ -38,7 +38,7 @@ jobs:
     extra_build_args: CODE_COVERAGE=TRUE
     extra_install_step:
     - script: |
-              sudo apt-get install --assumeyes mingw64-gcc
+              sudo apt-get install -y gcc-mingw-w64
       displayName: Install Windows Resource Compiler for Linux
     tool_chain_tag: 'GCC5'
     vm_image: $(vm_image)

--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-build:latest",
+  "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-dev:latest",
   "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {

--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/tianocore/containers/fedora-37-dev:latest",
+  "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-build:latest",
   "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Updates the default Linux build container from Fedora 37 to
Ubuntu 22.

The container feed switched from `ghcr.io/tianocore/containers`
to `ghcr.io/microsoft/mu_devops`.

Note: This is marked as a breaking change because of the distro change
from Fedora to Ubuntu. Commands run inside the container such as those
interacting with the package manager need to be reviewed and updated.