### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v3.0.0

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v2.5.1" %}
+{% set mu_devops = "v3.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v2.5.3...v3.0.0

General release info: https://github.com/microsoft/mu_devops/releases

A major release is being made because of a change in the container
images used in Project Mu pipelines.