### PR TITLE
.sync/Files.yml: Sync SECURITY.md to mu_devops

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -216,6 +216,7 @@ group:
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
+      microsoft/mu_devops
       microsoft/mu_feature_config
       microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi


### PR DESCRIPTION
Additionally syncs the file to mu_devops since it is missing. Also
prevents the `microsoft-github-policy-service` bot from creating PRs
to add a SECURITY.md file.