### PR TITLE
Notebooks/PullRequests.github-issues: Bump completed PR start date

### DIFF
--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -47,7 +47,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// This needs to be bumped very occassionally (annually likely) to prevent\r\n// the maximum allowed number of results from being reached.\r\n$since=2022-01-01\r\n\r\n$repos is:closed type:pr sort:created-desc closed:>$since"
+    "value": "// This needs to be bumped very occassionally (annually likely) to prevent\r\n// the maximum allowed number of results from being reached.\r\n$since=2023-01-01\r\n\r\n$repos is:closed type:pr sort:created-desc closed:>$since"
   },
   {
     "kind": 1,


### PR DESCRIPTION
Updates the year from `2022` to `2023` to reduce the total number of
PRs returned (which is limited by GitHub).