### PR TITLE
.sync/dependabot: Update PIP modules weekly

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -47,6 +47,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
       timezone: "America/Los_Angeles"
       time: "23:00"
     labels:
@@ -62,7 +63,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"
     commit-message:

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -45,7 +45,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"
     commit-message:


### PR DESCRIPTION
Checks for PIP module updates weekly instead of daily. The number of
updates was too frequent for CI resources and reviewer overhead.

Also explicitly sets the submodule weekly update day to Tuesday so
PIP and submodules updates can both be available Wednesday morning
for review and merge.