### PR TITLE
Publish coverage on even with skipped builds

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -163,7 +163,7 @@ jobs:
   dependsOn:
   - ${{ each item in parameters.build_matrix }}:
     - Build_${{ item.Key }}
-  condition: and(not(Canceled(), not(Failed()))
+  condition: and(not(Canceled()), not(Failed()))
 
   workspace:
     clean: all

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -163,6 +163,18 @@ jobs:
   dependsOn:
   - ${{ each item in parameters.build_matrix }}:
     - Build_${{ item.Key }}
+
+  condition: |
+    and
+    (
+    - ${{ each item in parameters.build_matrix }}:
+      ${{ if ne(item.Value.SelfHostAgent, true) }}:
+        eq(dependencies.Build_${{ item.Key }}.result, 'Succeeded'),
+      ${{ else }}:
+        in(dependencies.WebApp2.result, 'Succeeded', 'Skipped'),
+    # This to deal with the commas above...
+    True
+    )
   workspace:
     clean: all
 

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -163,18 +163,8 @@ jobs:
   dependsOn:
   - ${{ each item in parameters.build_matrix }}:
     - Build_${{ item.Key }}
+  condition: and(not(Canceled(), not(Failed()))
 
-  condition: |
-    and
-    (
-    - ${{ each item in parameters.build_matrix }}:
-      ${{ if ne(item.Value.SelfHostAgent, true) }}:
-        eq(dependencies.Build_${{ item.Key }}.result, 'Succeeded'),
-      ${{ else }}:
-        in(dependencies.WebApp2.result, 'Succeeded', 'Skipped'),
-    # This to deal with the commas above...
-    True
-    )
   workspace:
     clean: all
 


### PR DESCRIPTION
Current pipeline job for publishing coverage will skip the jobs if there are a few jobs being skipped. However, some skips are expected, such as some jobs that should be run on selfhosted agents, but no agents are available on the public site.

This change will update the publish coverage job's condition to ignore the skipped conditions, such that it will always run the job as long as there the previous job(s) not failing or being cancelled.