### PR TITLE
.github/workflows/Labeler.yml: Update workflows

### DIFF
--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
 
       - name: Apply Labels Based on PR Messages
-        uses: github/issue-labeler@v2.5
+        uses: github/issue-labeler@v3.1
         with:
           configuration-path: .github/workflows/label-issues/regex-pull-requests.yml
           enable-versioned-regex: 0

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Apply Labels Based on PR File Paths
-        uses: actions/labeler@v4
+        uses: actions/labeler@v4.1.0
         with:
           configuration-path: .github/workflows/label-issues/file-paths.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates `github/issue-labeler` from `v2.5` to `v3.1`.

Includes the following fixes (occassionally impacting Mu PRs):

- Issue labels that do not match a regex will no longer be removed
- Support empty body and only remove existing labels

---

Updates `actions/labeler` from `v4` to `v4.1.0`.

No major known changes that impact Mu DevOps.