### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v4.0.5

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v4.0.0" %}
+{% set mu_devops = "v4.0.5" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v4.0.0...v4.0.5

General release info: https://github.com/microsoft/mu_devops/releases

In particular, this rolls out an update to the issue labeler action
to bring it up to latest.