### PR TITLE
ReleaseDrafter.yml: Set Mu branches in all cases [Rebase & FF]

### DIFF
--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -48,7 +48,6 @@ jobs:
 
     steps:
       - name: Download Version Information
-        if: ${{ startsWith(github.ref, 'refs/heads/release') }}
         id: download_ver_info
         shell: bash
         run: |
@@ -58,7 +57,6 @@ jobs:
           curl $versionFileUrl --output "${localFilePath}"
           echo "file_path=${localFilePath}" >> $GITHUB_ENV
       - name: Extract Version Information
-        if: ${{ startsWith(github.ref, 'refs/heads/release') }}
         id: extract_ver_info
         shell: bash
         env:

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v5.0.0" %}
+{% set mu_devops = "v5.0.1" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}


### PR DESCRIPTION
The `*_mu_branch` workflow variables were not set in some cases to
reduce workflow execution time but logically the variables should
be set to ensure the step conditionals work as expected.