### PR TITLE
Added fetchdepth to disable default shallow checkout in new pipelines

### DIFF
--- a/Jobs/CreateBuildMatrix.yml
+++ b/Jobs/CreateBuildMatrix.yml
@@ -36,6 +36,7 @@ jobs:
 
     steps:
     - checkout: none
+       fetchDepth: 0
 
     - task: PowerShell@2
       name: CalculateMatrix

--- a/Jobs/CreateBuildMatrix.yml
+++ b/Jobs/CreateBuildMatrix.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - checkout: none
-       fetchDepth: 0
+      fetchDepth: 0
 
     - task: PowerShell@2
       name: CalculateMatrix

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -71,6 +71,7 @@ steps:
 - ${{ if eq(parameters.checkout_self, true) }}:
   - checkout: self
     clean: true
+    fetchDepth: 0
     # Note: Depth cannot be limited if PR Eval is used. A pipeline may choose
     #       to use a shallow checkout if PR eval is not used.
 

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -83,6 +83,7 @@ steps:
 - ${{ if eq(parameters.checkout_self, true) }}:
   - checkout: self
     clean: true
+    fetchDepth: 0
     # Note: Depth cannot be limited if PR Eval is used
 
 - template: SetupPythonPreReqs.yml

--- a/Steps/RunPatchCheck.yml
+++ b/Steps/RunPatchCheck.yml
@@ -24,6 +24,7 @@ pool:
 steps:
 - checkout: self
   clean: true
+  fetchDepth: 0
 
 - template: Steps/SetupPythonPreReqs.yml
 - script: |


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines#shallow-fetch

`New pipelines created after the [September 2022 Azure DevOps sprint 209 update](https://learn.microsoft.com/en-us/azure/devops/release-notes/2022/sprint-209-update) have Shallow fetch enabled by default and configured with a depth of 1. Previously the default was not to shallow fetch. To check your pipeline, view the Shallow fetch setting in the [pipeline settings UI](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git#shallow-fetch).`

Adding fetchdepth of 0 to disable default of shallow checkout for new pipelines using mu_devops. 