### PR TITLE
Add checkout_self parameter to prevent additional checkouts

### DIFF
--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -5,10 +5,17 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
+parameters:
+- name: checkout_self
+  displayName: Perform self checkout step
+  type: boolean
+  default: true
+
 steps:
-- checkout: self
-  clean: true
-  fetchDepth: 1
+- ${{ if eq(parameters.checkout_self, true) }}:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
 
 #
 # Download the build


### PR DESCRIPTION
A specific container that does checkout prior to running mu_devops runs into problems with multiple checkout statements. It places the repo under multiple directories.

Adding a parameter to prevent checkout of the repo again for the code coverage step. 