### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v5.0.6 (and container)

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,11 +30,11 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v5.0.4" %}
+{% set mu_devops = "v5.0.6" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}
 {% set previous_mu_release_branch = "release/202208" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:ea6d2e6" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:3bf70b5" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v5.0.4...v5.0.6

General release info: https://github.com/microsoft/mu_devops/releases

- The `ubuntu-22-build` container image is also updated to the latest: `3bf70b5`.