### PR TITLE
Add Rust Support [Rebase & FF]

### DIFF
--- a/.azurepipelines/GetCargoMake.yml
+++ b/.azurepipelines/GetCargoMake.yml
@@ -1,0 +1,54 @@
+## @file
+# Azure Pipeline to download Cargo Make and save it as a pipeline artifact that
+# can be accessed by other pipelines.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+schedules:
+# At 1:00 on Monday
+# https://crontab.guru/#0_1_*_*_1
+- cron: 0 1 * * 1
+  branches:
+    include:
+    - main
+  always: true
+
+jobs:
+- job: Update_Cargo_Make
+  displayName: Update Cargo Make
+
+  pool:
+    vmImage: windows-latest
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
+    fetchTags: false
+
+  - script: pip install requests --upgrade
+    displayName: Install and Upgrade pip Modules
+    condition: succeeded()
+
+  - task: PythonScript@0
+    displayName: Download and Stage Cargo Make
+    env:
+      BINARIES_DIR: "$(Build.BinariesDirectory)"
+      BINARY_NAME: "cargo-make"
+      DOWNLOAD_DIR: "$(Build.ArtifactStagingDirectory)"
+      REPO_URL: "https://api.github.com/repos/sagiegurari/cargo-make/releases"
+    inputs:
+      scriptSource: filePath
+      scriptPath: Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+      workingDirectory: $(Agent.BuildDirectory)
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Cargo Make
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(Build.BinariesDirectory)
+      ArtifactName: Binaries
+    condition: succeeded()

--- a/.azurepipelines/GetCargoTarpaulin.yml
+++ b/.azurepipelines/GetCargoTarpaulin.yml
@@ -1,0 +1,54 @@
+## @file
+# Azure Pipeline to download Cargo Tarpaulin and save it as a pipeline artifact that
+# can be accessed by other pipelines.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+schedules:
+# At 1:00 on Monday
+# https://crontab.guru/#0_1_*_*_1
+- cron: 0 1 * * 1
+  branches:
+    include:
+    - main
+  always: true
+
+jobs:
+- job: Update_Cargo_Tarpaulin
+  displayName: Update Cargo Tarpaulin
+
+  pool:
+    vmImage: windows-latest
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
+    fetchTags: false
+
+  - script: pip install requests --upgrade
+    displayName: Install and Upgrade pip Modules
+    condition: succeeded()
+
+  - task: PythonScript@0
+    displayName: Download and Stage Cargo Tarpaulin
+    env:
+      BINARIES_DIR: "$(Build.BinariesDirectory)"
+      BINARY_NAME: "cargo-tarpaulin"
+      DOWNLOAD_DIR: "$(Build.ArtifactStagingDirectory)"
+      REPO_URL: "https://api.github.com/repos/xd009642/tarpaulin/releases"
+    inputs:
+      scriptSource: filePath
+      scriptPath: Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+      workingDirectory: $(Agent.BuildDirectory)
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Cargo Tarpaulin
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(Build.BinariesDirectory)
+      ArtifactName: Binaries
+    condition: succeeded()

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -130,6 +130,25 @@ group:
     repos: |
       microsoft/mu_tiano_platforms
 
+# Development Container - Common for CI based repos
+  - files:
+    - source: .sync/devcontainer/devcontainer.json
+      dest: .devcontainer/devcontainer.json
+    repos: |
+      microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
+      microsoft/mu_crypto_release
+      microsoft/mu_feature_config
+      microsoft/mu_feature_dfci
+      microsoft/mu_feature_ipmi
+      microsoft/mu_feature_uefi_variable
+      microsoft/mu_oem_sample
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_plus
+      microsoft/mu_feature_mm_supv
+
 # GitHub Templates - Contributing
   - files:
     - source: .sync/github_templates/contributing/CONTRIBUTING.md
@@ -530,21 +549,3 @@ group:
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
 
-# Development Container - Common for CI based repos
-  - files:
-    - source: .sync/devcontainer/devcontainer.json
-      dest: .devcontainer/devcontainer.json
-    repos: |
-      microsoft/mu_basecore
-      microsoft/mu_common_intel_min_platform
-      microsoft/mu_crypto_release
-      microsoft/mu_feature_config
-      microsoft/mu_feature_dfci
-      microsoft/mu_feature_ipmi
-      microsoft/mu_feature_uefi_variable
-      microsoft/mu_oem_sample
-      microsoft/mu_plus
-      microsoft/mu_silicon_arm_tiano
-      microsoft/mu_silicon_intel_tiano
-      microsoft/mu_tiano_plus
-      microsoft/mu_feature_mm_supv

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -549,3 +549,15 @@ group:
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
 
+# Rust - Formatting configuration
+  - files:
+    - source: .sync/rust_config/Makefile.toml
+      dest: Makefile.toml
+    - source: .sync/rust_config/rust-toolchain.toml
+      dest: rust-toolchain.toml
+      template: true
+    - source: .sync/rust_config/rustfmt.toml
+      dest: rustfmt.toml
+    repos: |
+      microsoft/mu_basecore
+      microsoft/mu_plus

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -549,6 +549,14 @@ group:
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
 
+# Rust - Pipeline Files
+  - files:
+    - source: .sync/azure_pipelines/RustSetupSteps.yml
+      dest: Steps/RustSetupSteps.yml
+      template: true
+    repos: |
+      microsoft/mu_devops
+
 # Rust - Formatting configuration
   - files:
     - source: .sync/rust_config/Makefile.toml

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -69,12 +69,20 @@ parameters:
   displayName: Extra Jobs to be run after build
   type: jobList
   default: []
+- name: rust_build
+  displayName: Whether Rust code is being built
+  type: boolean
+  default: false
 
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
     linux_container_image: {{ sync_version.linux_build_container }}
 {% raw %}
+    ${{ if eq(parameters.rust_build, true) }}:
+      linux_container_options: --security-opt seccomp=unconfined
+      extra_steps:
+      - template: Steps/RustSetupSteps.yml@mu_devops
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
@@ -87,6 +95,22 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: ${{ parameters.container_build }}
+
+- ${{ if eq(parameters.rust_build, true) }}:
+  - job: CargoCmds
+    displayName: Workspace Cargo Commands
+
+    container:
+{% endraw %}
+      image: {{ sync_version.linux_build_container }}
+{% raw %}
+      options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
+
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - template: Steps/RustCargoSteps.yml@mu_devops
 
 - ${{ parameters.extra_jobs }}
 {% endraw %}

--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -1,0 +1,109 @@
+## @file
+# Azure Pipelines step to run common Rust steps.
+#
+# Cargo should be installed on the system prior to invoking this template.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{% import '../Version.njk' as sync_version -%}
+
+{% raw %}
+# NOTE: Because this pipeline YAML file is a Nunjucks template, the pipeline syntax of `{{}}` will conflict with
+#       Nunjucks style. Surround pipeline YAML code that uses `{{}}` within `raw` and `endraw` tags
+#       to allow it to pass through Nunjucks processing.
+{% endraw %}
+
+steps:
+
+- script: |
+    python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]{}'.format(os.path.join(os.environ['USERPROFILE'], '.cargo', 'bin')))"
+  displayName: Get Cargo bin Path (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- script: |
+    python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]/.cargo/bin')"
+  displayName: Get Cargo bin Path (Linux)
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+- task: CmdLine@2
+  displayName: Setup Cargo Dir Permissions (Linux)
+  target: host
+  inputs:
+    script: |
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.cargo
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.cargo
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.rustup
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.rustup
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+#
+# Linux will use a container image pre-loaded with the designated Rust version. Windows does not use a container
+# image, but will have a VM image with a very recent version of Rust installed. This step installs the same toolchain
+# version used in the Linux container for consistency between the two. The cargo-make and cargo-tarpaulin versions
+# placed in the container image are the latest at the time the image is built. That should be equal to or less than
+# the latest version available when the pipeline is run. Get the latest available in the cache pipelines and use
+# those on both Linux and Windows agents for consistency in the pipeline runs.
+#
+- script: |
+    rustup install {{ sync_version.rust_toolchain }}
+    rustup default {{ sync_version.rust_toolchain }}
+  displayName: Install Rust {{ sync_version.rust_toolchain }} (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Make (Windows)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 166
+    targetPath: '$(cargoBinPath)\'
+    itemPattern: '**/cargo-make.exe'
+    artifactName: Binaries
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Make (Linux)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 166
+    targetPath: '$(Agent.TempDirectory)'
+    itemPattern: '**/cargo-make'
+    artifactName: Binaries
+  condition: eq(variables['Agent.OS'], 'Linux')
+- script: |
+    cp $AGENT_TEMPDIRECTORY/cargo-make /.cargo/bin
+  displayName: Copy cargo-make
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Tarpaulin (Windows)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 167
+    targetPath: '$(cargoBinPath)\'
+    itemPattern: '**/cargo-tarpaulin.exe'
+    artifactName: Binaries
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Tarpaulin (Linux)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 167
+    targetPath: '$(Agent.TempDirectory)'
+    itemPattern: '**/cargo-tarpaulin'
+    artifactName: Binaries
+  condition: eq(variables['Agent.OS'], 'Linux')
+- script: |
+    cp $AGENT_TEMPDIRECTORY/cargo-tarpaulin /.cargo/bin
+  displayName: Copy cargo-tarpaulin
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-x86_64-pc-windows-msvc
+  displayName: rustup add rust-src
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/.sync/rust_config/Makefile.toml
+++ b/.sync/rust_config/Makefile.toml
@@ -1,0 +1,49 @@
+[config]
+default_to_workspace = false
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+RUSTC_BOOTSTRAP = 1
+ARCH = "X64"
+TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
+PACKAGE_TARGET = {value = "-p ${CARGO_MAKE_TASK_ARGS}",condition = { env_true = [ "CARGO_MAKE_TASK_ARGS", ] } }
+
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
+COV_FLAGS = { value = "--out Html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
+
+[env.development]
+RUSTC_PROFILE = "dev"
+RUSTC_TARGET = "debug"
+
+[env.release]
+RUSTC_PROFILE = "release"
+RUSTC_TARGET = "release"
+
+[tasks.build]
+description = """Builds a single rust package.
+
+Customizations:
+    -p [development|release]: Builds in debug or release. Default: development
+    -e ARCH=[IA32|X64|AARCH64|LOCAL]: Builds with specifed arch. Default: X64
+
+Example:
+    `cargo make build RustModule`
+    `cargo make -p release build RustModule`
+    `cargo make -e ARCH=IA32 build RustLib`
+"""
+clear = true
+command = "cargo"
+args = ["build", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
+
+[tasks.test]
+description = "Builds all rust tests in the workspace. Example `cargo make test`"
+clear = true
+command = "cargo"
+args = ["test", "@@split(PACKAGE_TARGET, )", "@@split(TEST_FLAGS, )"]
+
+[tasks.coverage]
+description = "Build and run all tests and calculate coverage."
+clear = true
+command = "cargo"
+args = ["tarpaulin", "@@split(PACKAGE_TARGET, )", "@@split(COV_FLAGS, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]

--- a/.sync/rust_config/rust-toolchain.toml
+++ b/.sync/rust_config/rust-toolchain.toml
@@ -1,0 +1,4 @@
+{% import '../Version.njk' as sync_version -%}
+
+[toolchain]
+channel = "{{ sync_version.rust_toolchain }}"

--- a/.sync/rust_config/rustfmt.toml
+++ b/.sync/rust_config/rustfmt.toml
@@ -1,0 +1,21 @@
+# rustfmt (and cargo fmt) will automatically pick up this config when run in the workspace.
+
+# Note that some items are included here set to their default values. This is to explicitly
+# reveal settings for more common options.
+
+# Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
+
+edition = "2021"              # This would normally be picked up from Cargo.toml if not specified here
+force_explicit_abi = true     # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
+hard_tabs = false             # Always uses spaces for indentation and alignment
+max_width = 120               # The maximum width of each line
+merge_derives = false         # Do not merge derives into a single line (leave to author discretion).
+imports_granularity = "Crate" # Merge imports from a single crate into separate statements.
+newline_style = "Windows"     # Always use Windows line endings '\r\n'
+reorder_impl_items = false    # Do not force where type and const before macros and methods in impl blocks.
+reorder_imports = true        # Do reorder import and extern crate statements alphabetically for readability.
+reorder_modules = true        # Do reorder mod declarations alphabetically for readability.
+tab_spaces = 2                # Use 2 spaces for indentation (Rust default is 4).
+unstable_features = false     # Do not use unstable rustfmt features.
+use_small_heuristics = "Max"  # Set all granular width settings to the same as max_width (do not use heuristics)
+wrap_comments = false         # Leave comment formatting to author's discretion

--- a/Containers/Ubuntu-22/Dockerfile
+++ b/Containers/Ubuntu-22/Dockerfile
@@ -33,9 +33,11 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
+        curl \
         flex \
         git \
         lcov \
+        jq \
         m4 \
         make \
         mono-complete \
@@ -87,6 +89,35 @@ RUN mkdir -p iasl_temp && cd iasl_temp && \
 RUN wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" && \
     dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && \
     apt-get update && apt-get install -y powershell && apt-get clean
+
+#
+# Rust support
+#
+
+ENV CARGO_HOME="$HOME/.cargo"
+ENV RUSTUP_HOME="$HOME/.rustup"
+ENV PATH="$CARGO_HOME/bin:$PATH"
+
+# Install Rust/Cargo and extras (rust-src, rust fmt, cargo-make, cargo-tarpaulin)
+RUN VERSION_URL="https://raw.githubusercontent.com/microsoft/mu_devops/main/.sync/Version.njk" && \
+    RUST_VERSION=$(curl -s ${VERSION_URL} | grep -oP '(?<=rust_toolchain = ").*(?=")') && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
+    rustup component add rustfmt rust-src --toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu
+
+RUN mkdir cargo_downloads && \
+    cd cargo_downloads && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/sagiegurari/cargo-make/releases/download/$TAG_NAME/cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu.zip" && \
+    curl -L -o cargo-make.zip "$DOWNLOAD_URL" && \
+    unzip cargo-make.zip && \
+    mv cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu/cargo-make $CARGO_HOME/bin/ && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/xd009642/tarpaulin/releases/download/$TAG_NAME/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz" && \
+    curl -L -o cargo-tarpaulin.tar.gz "$DOWNLOAD_URL" && \
+    tar -xzvf cargo-tarpaulin.tar.gz && \
+    mv cargo-tarpaulin $CARGO_HOME/bin/ && \
+    cd .. && \
+    rm -r cargo_downloads
 
 #
 # Alternatives
@@ -145,7 +176,6 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
         autotools-dev \
         bc \
         build-essential \
-        curl \
         dosfstools \
         gcc \
         libglib2.0-dev \

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -35,6 +35,10 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
+- name: extra_post_build_steps
+  displayName: Extra Post-Build Steps
+  type: stepList
+  default: []
 - name: extra_steps
   displayName: Extra Steps
   type: stepList
@@ -148,6 +152,7 @@ jobs:
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}
+        extra_post_build_steps: ${{ parameters.extra_post_build_steps }}
         # This is to handle the matrices that do not specify this.
         ${{ if eq(item.Value.SelfHostAgent, true) }}:
           self_host_agent: true

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -129,7 +129,7 @@ jobs:
     ${{ if and(eq(parameters.container_build, true), not(contains(parameters.vm_image, 'windows')), ne(item.Value.SelfHostAgent, true)) }}:
       container:
         image: ${{ parameters.linux_container_image }}
-        options: ${{ parameters.linux_container_options }}
+        options: --name mu_devops_build_container ${{ parameters.linux_container_options }}
 
     steps:
     - ${{ parameters.extra_steps }}

--- a/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+++ b/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
@@ -1,0 +1,80 @@
+# @file DownloadCargoBinaryFromGitHub.py
+#
+# A script used in pipelines to download Cargo binaries from a given GitHub
+# repo.
+#
+# See the accompanying script readme for more details.
+#
+# The environment variables are (name and example value):
+# - `BINARIES_DIR` - `$(Build.BinariesDirectory)`
+# - `BINARY_NAME` - `cargo-make`
+# - `DOWNLOAD_DIR` - `$(Build.ArtifactStagingDirectory)`
+# - `REPO_URL` - `https://api.github.com/repos/sagiegurari/cargo-make/releases`
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import os
+import requests
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+BINARY_NAME = os.environ["BINARY_NAME"]
+REPO_URL = os.environ["REPO_URL"]
+BINARIES_DIR = Path(os.environ["BINARIES_DIR"])
+DOWNLOAD_DIR = Path(os.environ["DOWNLOAD_DIR"], "archives")
+
+# Ensure the directories exist
+BINARIES_DIR.mkdir(parents=True, exist_ok=True)
+DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+# Fetch the list of assets from the GitHub releases
+response = requests.get(REPO_URL)
+response.raise_for_status()
+releases = response.json()
+
+if len(releases) == 0:
+    print("Failed to find a release.")
+    exit(1)
+
+# Download assets
+for asset in releases[0]['assets']:
+    name = asset['name'].lower()
+    if ("x86_64-pc-windows-msvc" in name or "x86_64-unknown-linux-gnu" in name
+       and asset['name'].endswith(('.zip', '.tar.gz'))):
+        filepath = DOWNLOAD_DIR / asset['name']
+        print(f"Downloading {asset['name']}...")
+        with requests.get(asset['browser_download_url'], stream=True) as r:
+            with filepath.open('wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+# Extract files
+for filename in DOWNLOAD_DIR.iterdir():
+    extracted_dir = DOWNLOAD_DIR / filename.stem
+
+    print(f"Extracting {filename.name}...")
+    if filename.name.endswith('.zip'):
+        with zipfile.ZipFile(filename, 'r') as zip_ref:
+            zip_ref.extractall(extracted_dir)
+    elif filename.name.endswith('.tar.gz'):
+        with tarfile.open(filename, 'r:gz') as tar:
+            tar.extractall(path=extracted_dir)
+
+    def flatten_copy(src: Path, dst: Path, names: Iterable = ("",)):
+        if not dst.exists():
+            dst.mkdir(parents=True)
+
+        for item in src.iterdir():
+            print(f"item is {item}")
+            if item.is_dir():
+                flatten_copy(item, dst, names)
+            elif any(name.lower() in item.name.lower() for name in names):
+                shutil.copy2(item, dst)
+
+    # Copy extracted files to the binaries directory
+    flatten_copy(extracted_dir, BINARIES_DIR, (BINARY_NAME, "license"))

--- a/Scripts/DownloadCargoBinaryFromGitHub/Readme.md
+++ b/Scripts/DownloadCargoBinaryFromGitHub/Readme.md
@@ -1,0 +1,34 @@
+# Download Cargo Binary From GitHub Script
+
+[DownloadCargoBinaryFromGitHub.py](./DownloadCargoBinaryFromGitHub.py) is a script used in pipelines to download Cargo
+binaries from a given GitHub repo.
+
+## Responsibilities
+
+The script manages:
+
+- Downloading the binary onto the agent
+- Extracting relevant binaries
+  - Currently Windows and Linux GNU x86_64 binaries
+- Placing the binaries in the given binaries directory
+
+## Background
+
+This is intended to provide more fine grained control over the process (as opposed to built-in GitHub release download
+tasks), to optimize file filtering, and accommodate future adjustments such as expanding support for additional file
+checks or archive formats, etc. while also being portable between CI environments. For example, it can be directly
+reused between Azure Pipelines and GitHub workflows without swapping out tasks, changing service connection details,
+and so on while also encasing operations like file extraction.
+
+## Inputs
+
+Because this script is only intended to run in pipelines, it does not present a user-facing command-line parameter
+interface and accepts its input as environment variables that are expected to be passed in the environment variable
+section of the task that invokes the script.
+
+The environment variables are (name and example value):
+
+- `BINARIES_DIR` - `$(Build.BinariesDirectory)`
+- `BINARY_NAME` - `cargo-make`
+- `DOWNLOAD_DIR` - `$(Build.ArtifactStagingDirectory)`
+- `REPO_URL` - `https://api.github.com/repos/sagiegurari/cargo-make/releases`

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -62,6 +62,10 @@ parameters:
   displayName: Extra Install Steps
   type: stepList
   default: []
+- name: extra_post_build_steps
+  displayName: Extra Post-Build Steps
+  type: stepList
+  default: []
 - name: install_tools
   displayName: Install Build Tools
   type: boolean
@@ -157,6 +161,9 @@ steps:
     inputs:
       script: stuart_ci_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
     condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# Potential post-build steps
+- ${{ parameters.extra_post_build_steps }}
 
 # Publish Test Results to Azure Pipelines/TFS
 - task: PublishTestResults@2

--- a/Steps/RustCargoSteps.yml
+++ b/Steps/RustCargoSteps.yml
@@ -1,0 +1,45 @@
+## @file
+# Azure Pipelines step to run common Cargo commands.
+#
+# Cargo should be installed on the system prior to invoking this template.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+steps:
+
+- task: CmdLine@2
+  displayName: Setup Cargo Dir Permissions (Linux)
+  target: host
+  inputs:
+    script: |
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.cargo
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.cargo
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.rustup
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.rustup
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+- task: CmdLine@2
+  displayName: cargo fmt
+  inputs:
+    script: 'cargo fmt --all --check'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+    failOnStandardError: true
+  condition: succeeded()
+
+- task: CmdLine@2
+  displayName: cargo make test
+  inputs:
+    script: 'cargo make test'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+    failOnStandardError: true
+  condition: succeeded()
+
+- task: CmdLine@2
+  displayName: cargo make build
+  inputs:
+    script: 'cargo make build'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+    failOnStandardError: true
+  condition: succeeded()

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -1,0 +1,105 @@
+## @file
+# Azure Pipelines step to run common Rust steps.
+#
+# Cargo should be installed on the system prior to invoking this template.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+# NOTE: Because this pipeline YAML file is a Nunjucks template, the pipeline syntax of `{{}}` will conflict with
+#       Nunjucks style. Surround pipeline YAML code that uses `{{}}` within `raw` and `endraw` tags
+#       to allow it to pass through Nunjucks processing.
+
+steps:
+
+- script: |
+    python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]{}'.format(os.path.join(os.environ['USERPROFILE'], '.cargo', 'bin')))"
+  displayName: Get Cargo bin Path (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- script: |
+    python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]/.cargo/bin')"
+  displayName: Get Cargo bin Path (Linux)
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+- task: CmdLine@2
+  displayName: Setup Cargo Dir Permissions (Linux)
+  target: host
+  inputs:
+    script: |
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.cargo
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.cargo
+      /usr/bin/docker exec mu_devops_build_container chown -R vsts_azpcontainer:docker_azpcontainer /.rustup
+      /usr/bin/docker exec mu_devops_build_container chmod -R ug+rw /.rustup
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+#
+# Linux will use a container image pre-loaded with the designated Rust version. Windows does not use a container
+# image, but will have a VM image with a very recent version of Rust installed. This step installs the same toolchain
+# version used in the Linux container for consistency between the two. The cargo-make and cargo-tarpaulin versions
+# placed in the container image are the latest at the time the image is built. That should be equal to or less than
+# the latest version available when the pipeline is run. Get the latest available in the cache pipelines and use
+# those on both Linux and Windows agents for consistency in the pipeline runs.
+#
+- script: |
+    rustup install 1.71.1
+    rustup default 1.71.1
+  displayName: Install Rust 1.71.1 (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Make (Windows)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 166
+    targetPath: '$(cargoBinPath)\'
+    itemPattern: '**/cargo-make.exe'
+    artifactName: Binaries
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Make (Linux)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 166
+    targetPath: '$(Agent.TempDirectory)'
+    itemPattern: '**/cargo-make'
+    artifactName: Binaries
+  condition: eq(variables['Agent.OS'], 'Linux')
+- script: |
+    cp $AGENT_TEMPDIRECTORY/cargo-make /.cargo/bin
+  displayName: Copy cargo-make
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Tarpaulin (Windows)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 167
+    targetPath: '$(cargoBinPath)\'
+    itemPattern: '**/cargo-tarpaulin.exe'
+    artifactName: Binaries
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Cargo Tarpaulin (Linux)
+  inputs:
+    buildType: specific
+    project: mu
+    definition: 167
+    targetPath: '$(Agent.TempDirectory)'
+    itemPattern: '**/cargo-tarpaulin'
+    artifactName: Binaries
+  condition: eq(variables['Agent.OS'], 'Linux')
+- script: |
+    cp $AGENT_TEMPDIRECTORY/cargo-tarpaulin /.cargo/bin
+  displayName: Copy cargo-tarpaulin
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- script: rustup component add rustfmt rust-src --toolchain 1.71.1-x86_64-pc-windows-msvc
+  displayName: rustup add rust-src
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
This pull request adds Rust support to mu_devops with patterns that extend to Rust adoption in additional Project Mu repos.

The changes can be grouped into three high-level parts:

1. Sync Rust environment files to repos
2. Add pipeline support to build and test Rust code 
3. Update the build container to incorporate Rust support

These changes extend existing Rust efforts in Project Mu and improve user experience outside the CI environment.

---

### Commit/Change Overview

---

#### .azurepipelines: Add YAML to cache Cargo tools

These files are added so dedicated pipelines can download the latest
release from each tools GitHub repository and push the binaries to
the pipeline artifacts.

Project Mu pipelines dependent on Rust tools can access the tools
directly from the Project Mu pipeline artifacts which is faster
than building and more reliable than depending on infrastructure
outside the pipelines.

---

#### .sync/Files.yml: Move dev container section

Moves the section higher in the file to maintain alphabetic ordering
of sections.

---

#### .sync: Sync common Rust files

Syncs the following files to repos that support Rust builds.

- `Makefile.toml` - Cargo makefile configuration. Repos will no
  longer extend from `MU_BASECORE`.
- `rustfmt.toml` - The Rust formatting settings for the repo.

---

#### Jobs/PrGate.yml: Give the linux container a reliable name

Passes the `--name` parameter as a container creation option in
pipelines so steps that may need to operate on the container instance
have a fixed name to refer to the container by.

The name is: `mu_devops_build_container`

---

#### Steps: Add Rust templates

Adds two new step templates.

1. `RustSetupSteps.yml` - Prepare Cargo for Rust builds including
   build during the edk build process and perform other actions
   available during pre-firmware build.
2. `RustCargoSteps.yml.yml` - Steps to run common Cargo commands
   on the workspace. Cargo should be installed and the workspace
   source cloned before running these steps.

---

#### .sync/azure_pipelines/MuDevOpsWrapper.yml: Add rust support

Allows repos that extend the YAML template to pass a new parameter
`rust_build`. By default, the option is `false`. If `true`, then
the repo will be set up to build for Rust and Cargo commands will
be run at the workspace level to build and test code.

---

#### Dockerfile: Add Rust support

Updates the `build` container image to be able to build Rust code
(including Rust UEFI code).

The following additional applications are installed to assist with
setting up Rust dependencies:

  `curl`, `jq`, and `unzip`

The `CARGO_HOME` and `RUSTUP_HOME` environment variables are set in
the image and the cargo directory is added to the system path.

The version of Rust specified in `Version.njk` is installed alongside
support for other tools used in Project Mu Rust builds such as
`cargo-make` and `cargo-tarpaulin`. The latest release binaries are
pulled directly from their GitHub releases to minimze container
size impact.

The resulting container images can be used for local development and
within pipelines.

---

### Notes

- The Rust toolchain version is defined in `Version.njk`. The version is used in:
  - The Dockerfile to ensure the container version is in sync
  - The YAML pipeline files to ensure (Windows) pipelines are in sync
  - The [`rust-toolchain.toml`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) file to ensure local builds in repos are in sync

- The [Cargo make makefile](https://sagiegurari.github.io/cargo-make/) is no longer defined in `MU_BASECORE` and extended to repos. It is synced in whole to repos. Extending from `MU_BASECORE` unnecessarily complicated pipeline logic and required pulling `MU_BASECORE` through a submodule (or worse, an external git dependency) on an agent increasing build time.

- The container image build is structured to provide a ready-to-go Rust dev environment while also minimizing space. The previous `build` container size was ~1.94GB. Adding the Rust tools initially increased size to 3.41GB. With a variety of adjustments, the size now is ~2.58GB.

- After this PR completes, a docker container build will happen and a follow up PR will update the `Version.njk` file to use the new container build. After that PR is completed, repos dependent on the container will be able to access it.

---

File sync tested in the following PRs:

- [mu_basecore](https://github.com/makubacki/mu_basecore/pull/57)
- [mu_plus](https://github.com/makubacki/mu_plus/pull/3)
- [mu_devops](https://github.com/makubacki/mu_devops/pull/143)