### PR TITLE
Version.njk: Add Rust toolchain version

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -38,3 +38,6 @@
 
 {# The version of the ubuntu-22-build container to use. #}
 {% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:3bf70b5" %}
+
+{# The Rust toolchain version to use. #}
+{% set rust_toolchain = "1.71.1" %}


### PR DESCRIPTION
Adds the Rust toolchain version to the file so it can be referenced
in future changes that add Rust support to the repo.

This change needs to be broken out because the upcoming change will
refer to this entry in Version.njk in the main branch when testing
the container build in its PR checks.