### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v6.0.0 (and container)

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,14 +30,14 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v5.0.6" %}
+{% set mu_devops = "v6.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}
 {% set previous_mu_release_branch = "release/202208" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:3bf70b5" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc" %}
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.71.1" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v5.0.6...v6.0.0

General release info: https://github.com/microsoft/mu_devops/releases

- The `ubuntu-22-build` container image is also updated to the latest: `9ab29bc`.
  - Note: This is the first release with Rust dev support.
- v6.0.0 also brings some new changes in the pipelines for Project Mu repos to build rust in CI.