### PR TITLE
set autocrlf to false in containers

### DIFF
--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-dev:latest",
-  "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
+  "postCreateCommand": "git config --global --add safe.directory '*' && git config --global core.autocrlf false && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.sync/devcontainer/devcontainer.json
+++ b/.sync/devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-dev:latest",
-  "postCreateCommand": "git config --global --add safe.directory '*' && git config --global core.autocrlf false && pip install --upgrade -r pip-requirements.txt",
+  "postCreateCommand": "git config --global --add safe.directory '*' && git config --global --add core.autocrlf false && pip install --upgrade -r pip-requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
`core.autocrlf = true` is a common pitfall when edk2 developers create a new file. It is always suggested to have this git config value turned off when developing EDKII UEFI firmware. Updates the container to have this git config set as expected.