### PR TITLE
Add mu_tiano_platforms to Rust Sync

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -569,3 +569,4 @@ group:
     repos: |
       microsoft/mu_basecore
       microsoft/mu_plus
+      microsoft/mu_tiano_platforms

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -73,6 +73,11 @@ parameters:
   displayName: Whether Rust code is being built
   type: boolean
   default: false
+- name: extra_cargo_steps
+  displayName: Extra Steps to Run Before Standard Cargo Steps
+  type: stepList
+  default:
+    - script: echo No extra cargo steps provided
 
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
@@ -110,6 +115,7 @@ jobs:
     - checkout: self
       fetchDepth: 1
       clean: true
+    - ${{ parameters.extra_cargo_steps }}
     - template: Steps/RustCargoSteps.yml@mu_devops
 
 - ${{ parameters.extra_jobs }}


### PR DESCRIPTION
Two changes:

**Add `extra_cargo_steps` parameter in MuDevOpsWrapper.yml**

The `extra_cargo_steps` parameter allows a repo extending
MuDevOpsWrapper.yml to specify a step list that should be executed
before running the standard set of cargo commands in the repo
(to build and test).

---

**Opt mu_tiano_platforms into Rust file sync**

Syncs the normal set of workspace-level Rust files to the
mu_tiano_platforms repo.
