### PR TITLE
.sync/rust_config/Makefile.toml: Add check task

### DIFF
--- a/.sync/rust_config/Makefile.toml
+++ b/.sync/rust_config/Makefile.toml
@@ -36,6 +36,18 @@ clear = true
 command = "cargo"
 args = ["build", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
 
+[tasks.check]
+description = "Checks rust code for errors. Example `cargo make check`"
+clear = true
+command = "cargo"
+args = ["check", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
+
+[tasks.check_json]
+description = "Checks rust code for errors with results in JSON. Example `cargo make check_json`"
+clear = true
+command = "cargo"
+args = ["check", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )", "--message-format=json"]
+
 [tasks.test]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"
 clear = true


### PR DESCRIPTION
The VS Code `rust-analyzer` plugin uses `cargo check` to find
problems. We use custom flags/target info with `cargo make`.

This adds a `cargo make check` command that reuses similar
flags to our build so the check results are similar. `check_json`
is added to be used by tools like VS Code that need JSON
output.