### PR TITLE
.sync/workflows/leaf/codeql: Remove build dirs

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -399,6 +399,29 @@ jobs:
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
       run: stuart_build -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
+    - name: Build Cleanup
+      id: build_cleanup
+      shell: python
+      run: |
+        import os
+        import shutil
+        from pathlib import Path
+
+        dirs_to_delete = ['ia32', 'x64', 'arm', 'aarch64']
+
+        def delete_dirs(path: Path):
+            if path.exists() and path.is_dir():
+                if path.name.lower() in dirs_to_delete:
+                    print(f'Removed {str(path)}')
+                    shutil.rmtree(path)
+                    return
+
+                for child_dir in path.iterdir():
+                    delete_dirs(child_dir)
+
+        build_path = Path(os.environ['GITHUB_WORKSPACE'], 'Build')
+        delete_dirs(build_path)
+
     - name: Upload Build Logs As An Artifact
       uses: actions/upload-artifact@v3
       if: success() || failure()

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -342,6 +342,29 @@ jobs:
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
       run: stuart_ci_build -c .pytool/CISettings.py -t DEBUG -p ${{ matrix.package }} -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
+    - name: Build Cleanup
+      id: build_cleanup
+      shell: python
+      run: |
+        import os
+        import shutil
+        from pathlib import Path
+
+        dirs_to_delete = ['ia32', 'x64', 'arm', 'aarch64']
+
+        def delete_dirs(path: Path):
+            if path.exists() and path.is_dir():
+                if path.name.lower() in dirs_to_delete:
+                    print(f'Removed {str(path)}')
+                    shutil.rmtree(path)
+                    return
+
+                for child_dir in path.iterdir():
+                    delete_dirs(child_dir)
+
+        build_path = Path(os.environ['GITHUB_WORKSPACE'], 'Build')
+        delete_dirs(build_path)
+
     - name: Upload Build Logs As An Artifact
       uses: actions/upload-artifact@v3
       if: success() || failure()


### PR DESCRIPTION
Intermediate build files are sometimes left in build directories
during CodeQL execution. This is particularly more prevalent in
module directories that contain Rust files. These files have very
long names, for example:

```
D:\a\mu_tiano_platforms\Build\QemuQ35Pkg
  \DEBUG_VS2022\X64\MsCorePkg\HelloWorldRustDxe\HelloWorldRustDxe
  \DEBUG\x86_64-unknown-uefi\debug\incremental
  \rust_boot_services_allocator_dxe-2f5m6unckl0t8
  \s-gorl2pbwn9-18oh534-e4zntah436u40i7hceav0825j
```

CodeQL actions have well known and unresolved issues with long paths
when they're scanning directories for files.

The directories where these files may be left are not needed after
build and it takes about 3 seconds to remove them so that is done
in this change.

---

Tested on fork. Example:
https://github.com/makubacki/mu_tiano_platforms/actions/runs/6204825673