### PR TITLE
RustSetupSteps: Add target triple detection

### DIFF
--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -28,6 +28,7 @@ steps:
     arch = platform.machine()
 
     rust_targets = {
+        ('Windows', 'aarch64'): 'aarch64-pc-windows-msvc',
         ('Windows', 'x86_64'): 'x86_64-pc-windows-msvc',
         ('Windows', 'i386'): 'i686-pc-windows-msvc',
         ('Linux', 'x86_64'): 'x86_64-unknown-linux-gnu',

--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -17,30 +17,40 @@
 
 steps:
 
-- name: Get Host Rust Target Triple
-  id: get_rust_target_triple
-  shell: python
-  run: |
-    import os
-    import platform
+# Note: This uses a local lookup table as opposed to `rustc -vV` since this is a Rust setup
+#       template that tries to minimize assumptions about Rust tools already on a system.
+- task: PythonScript@0
+  displayName: Get Host Rust Target Triple
+  inputs:
+    scriptSource: inline
+    workingDirectory: $(Agent.BuildDirectory)
+    script: |
+      import os
+      import platform
 
-    system = platform.system()
-    arch = platform.machine()
+      system = platform.system()
+      arch = platform.machine()
 
-    rust_targets = {
-        ('Windows', 'aarch64'): 'aarch64-pc-windows-msvc',
-        ('Windows', 'x86_64'): 'x86_64-pc-windows-msvc',
-        ('Windows', 'i386'): 'i686-pc-windows-msvc',
-        ('Linux', 'x86_64'): 'x86_64-unknown-linux-gnu',
-        ('Linux', 'aarch64'): 'aarch64-unknown-linux-gnu',
-        ('Linux', 'i386'): 'i686-unknown-linux-gnu',
-    }
+      rust_targets = {
+          ('Windows', 'x86_64'): 'x86_64-pc-windows-msvc',
+          ('Windows', 'AMD64'): 'x86_64-pc-windows-msvc',
+          ('Windows', 'i386'): 'i686-pc-windows-msvc',
+          ('Windows', 'i686'): 'i686-pc-windows-msvc',
+          ('Linux', 'x86_64'): 'x86_64-unknown-linux-gnu',
+          ('Linux', 'AMD64'): 'x86_64-unknown-linux-gnu',
+          ('Linux', 'aarch64'): 'aarch64-unknown-linux-gnu',
+          ('Linux', 'i386'): 'i686-unknown-linux-gnu',
+          ('Linux', 'i686'): 'i686-unknown-linux-gnu',
+      }
 
-    try:
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f'rust_target_triple={rust_targets[(system, arch)]}', file=fh)
-    except KeyError:
-        print(f'::error title=Unsupported Host Combination!::OS = {system}. Architecture = {arch}.')
+      print(f'System type = {system}')
+      print(f'Architecture = {arch}')
+
+      try:
+          print(f'##vso[task.setvariable variable=rust_target_triple]{rust_targets[(system, arch)]}')
+      except KeyError:
+          print(f'##[error]Unsupported Host Combination! OS = {system}. Architecture = {arch}.')
+          print(f'##vso[task.complete result=Failed;]Unsupported Host Combination! OS = {system}. Architecture = {arch}.')
 
 - script: |
     python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]{}'.format(os.path.join(os.environ['USERPROFILE'], '.cargo', 'bin')))"
@@ -129,6 +139,6 @@ steps:
   displayName: Copy cargo-tarpaulin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-- script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-${{ steps.get_rust_target_triple.outputs.rust_target_triple }}
+- script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-$(rust_target_triple)
   displayName: rustup add rust-src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -17,6 +17,30 @@
 
 steps:
 
+- name: Get Host Rust Target Triple
+  id: get_rust_target_triple
+  shell: python
+  run: |
+    import os
+    import platform
+
+    system = platform.system()
+    arch = platform.machine()
+
+    rust_targets = {
+        ('Windows', 'x86_64'): 'x86_64-pc-windows-msvc',
+        ('Windows', 'i386'): 'i686-pc-windows-msvc',
+        ('Linux', 'x86_64'): 'x86_64-unknown-linux-gnu',
+        ('Linux', 'aarch64'): 'aarch64-unknown-linux-gnu',
+        ('Linux', 'i386'): 'i686-unknown-linux-gnu',
+    }
+
+    try:
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'rust_target_triple={rust_targets[(system, arch)]}', file=fh)
+    except KeyError:
+        print(f'::error title=Unsupported Host Combination!::OS = {system}. Architecture = {arch}.')
+
 - script: |
     python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]{}'.format(os.path.join(os.environ['USERPROFILE'], '.cargo', 'bin')))"
   displayName: Get Cargo bin Path (Windows)
@@ -104,6 +128,6 @@ steps:
   displayName: Copy cargo-tarpaulin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-- script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-x86_64-pc-windows-msvc
+- script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-${{ steps.get_rust_target_triple.outputs.rust_target_triple }}
   displayName: rustup add rust-src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -14,6 +14,41 @@
 
 steps:
 
+# Note: This uses a local lookup table as opposed to `rustc -vV` since this is a Rust setup
+#       template that tries to minimize assumptions about Rust tools already on a system.
+- task: PythonScript@0
+  displayName: Get Host Rust Target Triple
+  inputs:
+    scriptSource: inline
+    workingDirectory: $(Agent.BuildDirectory)
+    script: |
+      import os
+      import platform
+
+      system = platform.system()
+      arch = platform.machine()
+
+      rust_targets = {
+          ('Windows', 'x86_64'): 'x86_64-pc-windows-msvc',
+          ('Windows', 'AMD64'): 'x86_64-pc-windows-msvc',
+          ('Windows', 'i386'): 'i686-pc-windows-msvc',
+          ('Windows', 'i686'): 'i686-pc-windows-msvc',
+          ('Linux', 'x86_64'): 'x86_64-unknown-linux-gnu',
+          ('Linux', 'AMD64'): 'x86_64-unknown-linux-gnu',
+          ('Linux', 'aarch64'): 'aarch64-unknown-linux-gnu',
+          ('Linux', 'i386'): 'i686-unknown-linux-gnu',
+          ('Linux', 'i686'): 'i686-unknown-linux-gnu',
+      }
+
+      print(f'System type = {system}')
+      print(f'Architecture = {arch}')
+
+      try:
+          print(f'##vso[task.setvariable variable=rust_target_triple]{rust_targets[(system, arch)]}')
+      except KeyError:
+          print(f'##[error]Unsupported Host Combination! OS = {system}. Architecture = {arch}.')
+          print(f'##vso[task.complete result=Failed;]Unsupported Host Combination! OS = {system}. Architecture = {arch}.')
+
 - script: |
     python -c "import os; print('##vso[task.setvariable variable=cargoBinPath]{}'.format(os.path.join(os.environ['USERPROFILE'], '.cargo', 'bin')))"
   displayName: Get Cargo bin Path (Windows)
@@ -101,6 +136,6 @@ steps:
   displayName: Copy cargo-tarpaulin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-- script: rustup component add rustfmt rust-src --toolchain 1.71.1-x86_64-pc-windows-msvc
+- script: rustup component add rustfmt rust-src --toolchain 1.71.1-$(rust_target_triple)
   displayName: rustup add rust-src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
Adds a step to determine the target triple for the host platform
that can be reused by other steps. It is currently used in the
`rustup component add` command issued later in the file.