### PR TITLE
.sync/Makefile.toml: Resolve cargo-tarpaulin breaking changes

### DIFF
--- a/.sync/rust_config/Makefile.toml
+++ b/.sync/rust_config/Makefile.toml
@@ -6,11 +6,10 @@ CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 RUSTC_BOOTSTRAP = 1
 ARCH = "X64"
 TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
-PACKAGE_TARGET = {value = "-p ${CARGO_MAKE_TASK_ARGS}",condition = { env_true = [ "CARGO_MAKE_TASK_ARGS", ] } }
 
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
-COV_FLAGS = { value = "--out Html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
+COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
 RUSTC_PROFILE = "dev"
@@ -19,6 +18,28 @@ RUSTC_TARGET = "debug"
 [env.release]
 RUSTC_PROFILE = "release"
 RUSTC_TARGET = "release"
+
+[tasks.individual-package-targets]
+script_runner = "@duckscript"
+script = '''
+args = get_env CARGO_MAKE_TASK_ARGS
+
+if is_empty ${args}
+  exit
+end
+
+1 = array ""
+2 = split ${args} ,
+3 = array_concat ${1} ${2}
+joined_args = array_join ${3} " -p "
+release ${1}
+release ${2}
+release ${3}
+
+joined_args = trim ${joined_args}
+set_env INDIVIDUAL_PACKAGE_TARGETS ${joined_args}
+release ${joined_args}
+'''
 
 [tasks.build]
 description = """Builds a single rust package.
@@ -34,28 +55,33 @@ Example:
 """
 clear = true
 command = "cargo"
-args = ["build", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
+args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )"]
+dependencies = ["individual-package-targets"]
 
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
 command = "cargo"
-args = ["check", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )"]
+args = ["check", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )"]
+dependencies = ["individual-package-targets"]
 
 [tasks.check_json]
 description = "Checks rust code for errors with results in JSON. Example `cargo make check_json`"
 clear = true
 command = "cargo"
-args = ["check", "@@split(PACKAGE_TARGET, )", "@@split(BUILD_FLAGS, )", "--message-format=json"]
+args = ["check", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )", "--message-format=json"]
+dependencies = ["individual-package-targets"]
 
 [tasks.test]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"
 clear = true
 command = "cargo"
-args = ["test", "@@split(PACKAGE_TARGET, )", "@@split(TEST_FLAGS, )"]
+args = ["test", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(TEST_FLAGS, )"]
+dependencies = ["individual-package-targets"]
 
 [tasks.coverage]
 description = "Build and run all tests and calculate coverage."
 clear = true
 command = "cargo"
-args = ["tarpaulin", "@@split(PACKAGE_TARGET, )", "@@split(COV_FLAGS, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]
+args = ["tarpaulin", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(COV_FLAGS, )", "--output-dir", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target"]
+dependencies = ["individual-package-targets"]


### PR DESCRIPTION
Tarpaulin 0.27 was released on September 17, 2023:
https://github.com/xd009642/tarpaulin/releases/tag/0.27.0

The clap crate (Command Line Argument Parser) dependency within
tarpaulin was upgraded in the 0.27 release from an old version
(v2) to the latest major version (v4):

```
  Upgraded from clap v2 to v4. This has a few changes, notably any
  arguments which can be specified more than once require multiple
  entries so --run-types doc test needs to be turned into
  --run-types doc --run-types test
```

This means passing packages to a single `-p` parameter as a comma-
separated list is no longer supported:

```
  [cargo-make] Execute Command: "cargo" "tarpaulin" "-p" \
    "HelloWorldRustDxe,RustBootServicesAllocatorDxe"

  cargo_tarpaulin::config: Creating config
  cargo_tarpaulin: Running Tarpaulin
  cargo_tarpaulin: Building project
  cargo_tarpaulin::cargo: Cleaning project
  error: invalid character `,` in pkgid:
    `HelloWorldRustDxe,RustBootServicesAllocatorDxe`, characters must
    be Unicode XID characters (numbers, `-`, `_`, or most letters)
```

Providing users the ability to pass packages separated by commas to
`cargo make coverage` is convenient and assumed in our documentation
and wrapper scripts.

This change retains the same user-facing interface to `cargo make coverage`
while using a duckscript within the cargo makefile to transform the
list to the format accepted by tarpaulin. Other commands are unchanged.

Duckscript is useful because it is readily embedded in cargo-make so
no additional dependencies are required and it is cross-platform.

---

In addition, a minor fix is made by changing `Html` to `html` for the
following issue:

```
  [cargo-make] Execute Command: "cargo" "tarpaulin" "--out" "Html"
    "--exclude-files" "**/tests/*" "--output-dir" "D:\\src\\mu_plus/target"
  error: invalid value 'Html' for '--out [<FMT>...]'
    [possible values: json, stdout, xml, html, lcov]

    tip: a similar value exists: 'html'
```