### PR TITLE
.sync/Files.yml: Drop Makefile.toml sync to mu_rust_hid

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -594,8 +594,6 @@ group:
 
 # Rust - Formatting configuration
   - files:
-    - source: .sync/rust_config/Makefile.toml
-      dest: Makefile.toml
     - source: .sync/rust_config/rust-toolchain.toml
       dest: rust-toolchain.toml
       template: true
@@ -605,4 +603,13 @@ group:
       microsoft/mu_basecore
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_tiano_platforms
+
+# Rust - Makefile (for UEFI builds)
+  - files:
+    - source: .sync/rust_config/Makefile.toml
+      dest: Makefile.toml
+    repos: |
+      microsoft/mu_basecore
+      microsoft/mu_plus
       microsoft/mu_tiano_platforms


### PR DESCRIPTION
Do not sync the file since the repo is not planned to host UEFI rust
code at this time which the makefile helps cater to.