### PR TITLE
Fix Python minor version and update to Python 3.12 [Rebase & FF]

### DIFF
--- a/.github/actions/submodule-release-updater/action.yml
+++ b/.github/actions/submodule-release-updater/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Set up Python Environment
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install PIP Modules
       shell: bash

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v6.5.1" %}
+{% set mu_devops = "v7.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '>=3.11'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 
@@ -129,7 +129,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '>=3.11'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 
@@ -129,7 +129,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '>=3.11'
+        python-version: '3.11'
 
     - name: Generate Package Matrix
       id: generate_matrix
@@ -94,7 +94,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '>=3.11'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Generate Package Matrix
       id: generate_matrix
@@ -94,7 +94,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: 'pip-requirements.txt'
 

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -24,7 +24,7 @@ steps:
 - ${{ if eq(parameters.install_python, true) }}:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: ">=3.10.6"
+      versionSpec: "3.11"
       architecture: x64
 
 - ${{ if eq(parameters.install_pip_modules, true) }}:

--- a/Steps/SetupPythonPreReqs.yml
+++ b/Steps/SetupPythonPreReqs.yml
@@ -24,7 +24,7 @@ steps:
 - ${{ if eq(parameters.install_python, true) }}:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: "3.11"
+      versionSpec: "3.12"
       architecture: x64
 
 - ${{ if eq(parameters.install_pip_modules, true) }}:


### PR DESCRIPTION
Because of the way the Python version was managed, pipelines already
started picking up [Python 3.12](https://www.python.org/downloads/release/python-3120/).

Also, tool like pytools are releasing 3.12 support. This change fixes
the minor version to prevent unintentional minor version updates in
the future and explicitly sets the minor version to `12`.

This files synced from this PR should merged into repos after the pytools
release is out with 3.12 support and this mu_basecore change is completed
(https://github.com/microsoft/mu_basecore/pull/586). Though since pipelines
already moved to 3.12 as-is, it won't make much of a practical difference.

Three commits:

---

**Fix Python minor version**

Set to Python 3.11 (current) but do not allow newer minor versions to
be picked up unless explicitly specified.

---

**Update to Python 3.12**

Repos had already started picking up 3.12 because the minor version
was previously not fixed. This change update the Python version to
3.12 to accelerate adoption and ensure compatibility.

---

**.sync/Version.njk: Update Mu repos to Mu DevOps v7.0.0**

Changes since last release:
https://github.com/microsoft/mu_devops/compare/v6.5.1...v7.0.0

General release info: https://github.com/microsoft/mu_devops/releases