### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v7.0.1

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,14 +30,14 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v7.0.0" %}
+{% set mu_devops = "v7.0.1" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}
 {% set previous_mu_release_branch = "release/202208" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:1082f35" %}
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.73.0" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v7.0.0...v7.0.1

Also updates the container to the latest version `1082f35`.

General release info: https://github.com/microsoft/mu_devops/releases