### PR TITLE
.sync/workflows: Pass Rust env tool exclusions in CodeQL flows

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -396,6 +396,7 @@ jobs:
       shell: pwsh
       working-directory: "Z:"
       env:
+        RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
       run: stuart_build -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -339,6 +339,7 @@ jobs:
 
     - name: CI Build
       env:
+        RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
       run: stuart_ci_build -c .pytool/CISettings.py -t DEBUG -p ${{ matrix.package }} -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 


### PR DESCRIPTION
Excludes tools that are not necessary to be present for CodeQL builds.

---

Can precede but pairs with [BaseTools/Plugin: Add tool exclusion to RustEnvironmentCheck](https://github.com/microsoft/mu_basecore/pull/602)