### PR TITLE
Update Code Coverage Calculations

### DIFF
--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -42,6 +42,9 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
+- name: calculate_code_coverage
+  displayName: Calculate Code Coverage From Unit Tests
+  default: false
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean
@@ -89,6 +92,7 @@ jobs:
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
+    calculate_code_coverage: ${{ parameters.calculate_code_coverage }}
     do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
     do_non_ci_build: ${{ parameters.do_non_ci_build }}
     build_matrix: ${{ parameters.build_matrix }}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -158,7 +158,6 @@ jobs:
         do_non_ci_build: ${{ parameters.do_non_ci_build }}
         do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
         do_pr_eval: ${{ parameters.do_pr_eval }}
-        calculate_code_coverage: ${{ parameters.calculate_code_coverage }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}
@@ -168,7 +167,10 @@ jobs:
           self_host_agent: true
         ${{ else }}:
           self_host_agent: false
-        extra_build_args: CODE_COVERAGE=TRUE
+        ${{ if eq(parameters.calculate_code_coverage, true) }}:
+          extra_build_args: CODE_COVERAGE=TRUE
+        ${{ else }}:
+          extra_build_args: ''
 
 - ${{ if eq(parameters.calculate_code_coverage, true) }}:
   - job: PublishCoverage

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -185,3 +185,7 @@ jobs:
 
     steps:
       - template: ../Steps/PublishCodeCoverage.yml
+        parameters:
+          reorganize_by_inf: true
+          extra_parse_args: -t NOOPT TOOL_CHAIN_TAG=$(tool_chain_tag)
+          build_file: ${{ parameters.build_file }}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -35,6 +35,9 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
+- name: calculate_code_coverage
+  displayName: Calculate Code Coverage
+  default: false
 - name: extra_post_build_steps
   displayName: Extra Post-Build Steps
   type: stepList
@@ -155,6 +158,7 @@ jobs:
         do_non_ci_build: ${{ parameters.do_non_ci_build }}
         do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
         do_pr_eval: ${{ parameters.do_pr_eval }}
+        calculate_code_coverage: ${{ parameters.calculate_code_coverage }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}
@@ -166,6 +170,7 @@ jobs:
           self_host_agent: false
         extra_build_args: CODE_COVERAGE=TRUE
 
+${{ if eq(parameters.calculate_code_coverage, true) }}:
 - job: PublishCoverage
   dependsOn:
   - ${{ each item in parameters.build_matrix }}:

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -170,18 +170,18 @@ jobs:
           self_host_agent: false
         extra_build_args: CODE_COVERAGE=TRUE
 
-${{ if eq(parameters.calculate_code_coverage, true) }}:
-- job: PublishCoverage
-  dependsOn:
-  - ${{ each item in parameters.build_matrix }}:
-    - Build_${{ item.Key }}
-  condition: and(not(Canceled()), not(Failed()))
+- ${{ if eq(parameters.calculate_code_coverage, true) }}:
+  - job: PublishCoverage
+    dependsOn:
+    - ${{ each item in parameters.build_matrix }}:
+      - Build_${{ item.Key }}
+    condition: and(not(Canceled()), not(Failed()))
 
-  workspace:
-    clean: all
+    workspace:
+      clean: all
 
-  pool:
-    vmImage: 'windows-latest'
+    pool:
+      vmImage: 'windows-latest'
 
-  steps:
-    - template: ../Steps/PublishCodeCoverage.yml
+    steps:
+      - template: ../Steps/PublishCodeCoverage.yml

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -37,6 +37,7 @@ parameters:
   default: true
 - name: calculate_code_coverage
   displayName: Calculate Code Coverage
+  type: boolean
   default: false
 - name: extra_post_build_steps
   displayName: Extra Post-Build Steps

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -173,11 +173,22 @@ steps:
     condition: and(gt(variables.pkg_count, 0), succeeded())
 
 - ${{ if eq(parameters.calculate_code_coverage, true) }}:
+  - task: PythonScript@0
+    displayName: Check For Coverage File
+    inputs:
+      scriptSource: 'inline'
+      script: |
+        import os
+        if os.path.exists('$(Build.SourcesDirectory)/Build/coverage.xml'):
+          print('##vso[task.setvariable variable=FileExists]true')
+        else:
+          print('##vso[task.setvariable variable=FileExists]false')
+
   - task: CmdLine@2
     displayName: Reorganize Code Coverage
     inputs:
       script: stuart_report coverage $(Build.SourcesDirectory)/Build/coverage.xml --by-package -p $(pkgs_to_build) -o $(Build.SourcesDirectory)/Build/coverage.xml
-    condition: and(gt(variables.pkg_count, 0), succeeded(), exists('$(Build.SourcesDirectory)/Build/coverage.xml'))
+    condition: and(gt(variables.pkg_count, 0), succeeded(), eq(variables.FileExists, 'true'))
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -176,7 +176,7 @@ steps:
   - task: CmdLine@2
     displayName: Reorganize Code Coverage
     inputs:
-      script: stuart_report coverage Build/coverage.xml --by-package -p $(pkgs_to_build) -o Build/coverage.xml
+      script: stuart_report coverage $(Build.SourcesDirectory)/Build/coverage.xml --by-package -p $(pkgs_to_build) -o $(Build.SourcesDirectory)/Build/coverage.xml
     condition: and(gt(variables.pkg_count, 0), succeeded(), exists('$(Build.SourcesDirectory)/Build/coverage.xml'))
 
 # Potential post-build steps

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -162,18 +162,6 @@ steps:
       script: stuart_ci_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
     condition: and(gt(variables.pkg_count, 0), succeeded())
 
-- ${{ if eq(parameters.calculate_code_coverage, true) }}:
-  - task: PythonScript@0
-    displayName: Check For Coverage File
-    inputs:
-      scriptSource: 'inline'
-      script: |
-        import pathlib
-        if pathlib.Path(r"$(Build.SourcesDirectory)", "Build", "coverage.xml").exists():
-          print('##vso[task.setvariable variable=FileExists]true')
-        else:
-          print('##vso[task.setvariable variable=FileExists]false')
-
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}
 

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -50,9 +50,6 @@ parameters:
   displayName: Perform non-CI Stuart Setup
   type: boolean
   default: false
-- name: calculate_code_coverage
-  displayName: Calculate Code Coverage
-  default: false
 - name: do_pr_eval
   displayName: Perform Stuart PR Evaluation
   type: boolean
@@ -151,13 +148,6 @@ steps:
     script: stuart_update -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
-# - ${{ if eq(parameters.calculate_code_coverage, true) }}:
-#   - task: CmdLine@2
-#     displayName: Stuart Parse ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
-#     inputs:
-#       script: stuart_parse -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets }} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
-#     condition: and(gt(variables.pkg_count, 0), succeeded())
-
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@2
     displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
@@ -183,12 +173,6 @@ steps:
           print('##vso[task.setvariable variable=FileExists]true')
         else:
           print('##vso[task.setvariable variable=FileExists]false')
-
-  # - task: CmdLine@2
-  #   displayName: Reorganize Code Coverage
-  #   inputs:
-  #     script: stuart_report coverage $(Build.SourcesDirectory)/Build/coverage.xml --by-package -p $(pkgs_to_build) -o $(Build.SourcesDirectory)/Build/coverage.xml
-  #   condition: and(gt(variables.pkg_count, 0), succeeded(), eq(variables.FileExists, 'true'))
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -178,8 +178,8 @@ steps:
     inputs:
       scriptSource: 'inline'
       script: |
-        import os
-        if os.path.exists('$(Build.SourcesDirectory)/Build/coverage.xml'):
+        import pathlib
+        if pathlib.Path(r"$(Build.SourcesDirectory)", "Build", "coverage.xml").exists():
           print('##vso[task.setvariable variable=FileExists]true')
         else:
           print('##vso[task.setvariable variable=FileExists]false')

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -151,12 +151,12 @@ steps:
     script: stuart_update -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
-- ${{ if eq(parameters.calculate_code_coverage, true) }}:
-  - task: CmdLine@2
-    displayName: Stuart Parse ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
-    inputs:
-      script: stuart_parse -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets }} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
-    condition: and(gt(variables.pkg_count, 0), succeeded())
+# - ${{ if eq(parameters.calculate_code_coverage, true) }}:
+#   - task: CmdLine@2
+#     displayName: Stuart Parse ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+#     inputs:
+#       script: stuart_parse -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets }} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+#     condition: and(gt(variables.pkg_count, 0), succeeded())
 
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@2
@@ -184,11 +184,11 @@ steps:
         else:
           print('##vso[task.setvariable variable=FileExists]false')
 
-  - task: CmdLine@2
-    displayName: Reorganize Code Coverage
-    inputs:
-      script: stuart_report coverage $(Build.SourcesDirectory)/Build/coverage.xml --by-package -p $(pkgs_to_build) -o $(Build.SourcesDirectory)/Build/coverage.xml
-    condition: and(gt(variables.pkg_count, 0), succeeded(), eq(variables.FileExists, 'true'))
+  # - task: CmdLine@2
+  #   displayName: Reorganize Code Coverage
+  #   inputs:
+  #     script: stuart_report coverage $(Build.SourcesDirectory)/Build/coverage.xml --by-package -p $(pkgs_to_build) -o $(Build.SourcesDirectory)/Build/coverage.xml
+  #   condition: and(gt(variables.pkg_count, 0), succeeded(), eq(variables.FileExists, 'true'))
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -50,6 +50,9 @@ parameters:
   displayName: Perform non-CI Stuart Setup
   type: boolean
   default: false
+- name: calculate_code_coverage
+  displayName: Calculate Code Coverage
+  default: false
 - name: do_pr_eval
   displayName: Perform Stuart PR Evaluation
   type: boolean
@@ -148,6 +151,13 @@ steps:
     script: stuart_update -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
+- ${{ if eq(parameters.calculate_code_coverage, true) }}:
+  - task: CmdLine@2
+    displayName: Stuart Parse ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    inputs:
+      script: stuart_parse -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets }} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
+    condition: and(gt(variables.pkg_count, 0), succeeded())
+
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@2
     displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
@@ -161,6 +171,12 @@ steps:
     inputs:
       script: stuart_ci_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
     condition: and(gt(variables.pkg_count, 0), succeeded())
+
+- ${{ if eq(parameters.calculate_code_coverage, true) }}:
+  - task: CmdLine@2
+    displayName: Reorganize Code Coverage
+    inputs:
+      script: stuart_report coverage Build/coverage.xml --by-package -p $(pkgs_to_build) -o Build/coverage.xml
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -177,6 +177,7 @@ steps:
     displayName: Reorganize Code Coverage
     inputs:
       script: stuart_report coverage Build/coverage.xml --by-package -p $(pkgs_to_build) -o Build/coverage.xml
+    condition: and(gt(variables.pkg_count, 0), succeeded(), exists('$(Build.SourcesDirectory)/Build/coverage.xml'))
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -34,7 +34,7 @@ steps:
 - ${{ if eq(parameters.setup_python, true ) }}:
   - template: SetupPythonPreReqs.yml
     parameters:
-      install_python: ${{ parameters.install_tools }}
+      install_python: true
 #
 # Download the build
 #

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -52,7 +52,7 @@ steps:
   displayName: Check For Coverage Files
 
 - task: CmdLine@2
-  displayName: Combine coverage Reports
+  displayName: Merge Coverage Reports
   inputs:
     script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -16,6 +16,7 @@ parameters:
   default: true
 - name: reorganize_by_inf
   displayName: Reorganize cobertura report by INF # Requires stuart_report & stuart_parse
+  type: boolean
   default: false
 - name: extra_parse_args
   displayName: Extra arguments for stuart_parse

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -19,6 +19,7 @@ parameters:
   default: false
 - name: extra_parse_args
   displayName: Extra arguments for stuart_parse
+  type: boolean
   default: ''
 - name: build_file
   displayName: Stuart Build File

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -34,12 +34,22 @@ steps:
   displayName: Check For Coverage Files
 
 - task: CmdLine@2
-  displayName: Create Coverage Report
+  displayName: Combine coverage Reports
   inputs:
     script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool
       reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/*coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura
   condition: gt(variables.coverage_file_count, 0)
+
+- task: CmdLine@2
+  displayName: Parse Workspace
+  inputs:
+    script: stuart_parse -c .pytool/CISettings.py
+
+- task: CmdLine@2
+  displayName: Organize report by INF
+  inputs:
+    script: stuart_report coverage $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml --by-package -o $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml
 
 - task: PublishCodeCoverageResults@1
   displayName: Publish Code Coverage

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -19,7 +19,7 @@ parameters:
   default: false
 - name: extra_parse_args
   displayName: Extra arguments for stuart_parse
-  type: boolean
+  type: string
   default: ''
 - name: build_file
   displayName: Stuart Build File

--- a/Steps/PublishCodeCoverage.yml
+++ b/Steps/PublishCodeCoverage.yml
@@ -10,6 +10,20 @@ parameters:
   displayName: Perform self checkout step
   type: boolean
   default: true
+- name: setup_python
+  displayName: Setup Python
+  type: boolean
+  default: true
+- name: reorganize_by_inf
+  displayName: Reorganize cobertura report by INF # Requires stuart_report & stuart_parse
+  default: false
+- name: extra_parse_args
+  displayName: Extra arguments for stuart_parse
+  default: ''
+- name: build_file
+  displayName: Stuart Build File
+  type: string
+  default: ".pytool/CISettings.py"
 
 steps:
 - ${{ if eq(parameters.checkout_self, true) }}:
@@ -17,6 +31,10 @@ steps:
     clean: true
     fetchDepth: 1
 
+- ${{ if eq(parameters.setup_python, true ) }}:
+  - template: SetupPythonPreReqs.yml
+    parameters:
+      install_python: ${{ parameters.install_tools }}
 #
 # Download the build
 #
@@ -41,15 +59,18 @@ steps:
       reportgenerator -reports:$(Build.ArtifactStagingDirectory)/coverage/**/*coverage.xml -targetdir:$(Build.ArtifactStagingDirectory)/Coverage -reporttypes:Cobertura
   condition: gt(variables.coverage_file_count, 0)
 
-- task: CmdLine@2
-  displayName: Parse Workspace
-  inputs:
-    script: stuart_parse -c .pytool/CISettings.py
+- ${{ if eq(parameters.reorganize_by_inf, true) }}:
+  - task: CmdLine@2
+    displayName: Parse Workspace
+    inputs:
+      script: stuart_parse -c ${{ parameters.build_file }} ${{ parameters.extra_parse_args }}
+    condition: gt(variables.coverage_file_count, 0)
 
-- task: CmdLine@2
-  displayName: Organize report by INF
-  inputs:
-    script: stuart_report coverage $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml --by-package -o $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml
+  - task: CmdLine@2
+    displayName: Organize report by INF
+    inputs:
+      script: stuart_report coverage $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml --by-package -o $(Build.ArtifactStagingDirectory)/Coverage/Cobertura.xml
+    condition: gt(variables.coverage_file_count, 0)
 
 - task: PublishCodeCoverageResults@1
   displayName: Publish Code Coverage


### PR DESCRIPTION
Update code coverage calculations to have the ability to reorganize the report by INF using `stuart_parse` and `stuart_report.`

I have confirmed this as working using MuDevOpsWrapper for MU_BASECORE PRs:

Windows: [Pipelines - Run 20231102.11 (azure.com)](https://dev.azure.com/projectmu/mu/_build/results?buildId=57362&view=codecoverage-tab)
Linux: [Pipelines - Run 20231102.11 (azure.com)](https://dev.azure.com/projectmu/mu/_build/results?buildId=57363&view=codecoverage-tab)