### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v7.1.0

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v7.0.1" %}
+{% set mu_devops = "v7.1.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v7.0.1...v7.1.0

General release info: https://github.com/microsoft/mu_devops/releases

---

This change is necessary when integrating 649a4ba to prevent the following failure:

```
/.azurepipelines/MuDevOpsWrapper.yml (Line: 92, Col: 30): Unexpected
  parameter 'calculate_code_coverage'
```