### PR TITLE
Steps/UploadCodeCoverage.yml: Remove dependency and conditionalize [Rebase & FF]

### DIFF
--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -101,17 +101,25 @@ steps:
     scriptSource: inline
     script: |
       from pathlib import Path
-      from edk2toollib.utility_functions import RunCmd
       import io
       import os
+      import subprocess
 
       COV_FLAG = os.environ['COV_FLAG']
       REPORT_DIR = os.environ['REPORT_DIR']
       UPLOAD_CMD = os.environ['UPLOAD_CMD']
-  
+
       for cov_file in Path(REPORT_DIR).rglob('*coverage.xml'):
-        outstream = io.StringIO()
-        params = f'-f {cov_file} -Z'
+        params = f'{UPLOAD_CMD} -f {cov_file} -Z'
         if COV_FLAG:
           params += f' -F {COV_FLAG}'
-        RunCmd(UPLOAD_CMD, params, outstream=outstream, raise_exception_on_nonzero=True)
+        process = subprocess.Popen(
+          [UPLOAD_CMD, params],
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE)
+        output, error = process.communicate()
+        print(f"##[debug]{output.decode('utf-8')}")
+        if process.returncode != 0:
+          print(f"##[error]{error.decode('utf-8')}")
+          raise Exception(f"{UPLOAD_CMD} failed with Return Code: "
+                          f"{process.returncode}.")

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -9,10 +9,6 @@
 ##
 
 parameters:
-- name: codecov_token
-  displayName: Codecov.io Token
-  type: string
-  default: ''
 - name: report_dir
   displayName: Code Coverage Report
   type: string
@@ -31,9 +27,11 @@ steps:
   - script: |
       pip install requests
     displayName: Install Python Dependencies for Codecov Uploader
+    condition: ne(variables['CODECOV_TOKEN'], '')
 
 - task: PythonScript@0
   displayName: Download and Verify Codecov Uploader
+  condition: ne(variables['CODECOV_TOKEN'], '')
   inputs:
     scriptSource: inline
     script: |
@@ -93,6 +91,7 @@ steps:
 
 - task: PythonScript@0
   displayName: Run Codecov Uploader ${{ parameters.flag }}
+  condition: ne(variables['CODECOV_TOKEN'], '')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}


### PR DESCRIPTION
Contains two changes related to uploading code coverage:

1. Remove edk2toollib dependency

   Some repos (like pure Rust repos) are expected not to depend on
   pytools. Since the codecov application can simply be run without
   `RunCmd()`, do that and prevent the need for those repos to depend
   on edk2toollib or unnecessary logic in the pipelines to bring it in.

2. Conditionalize coverage upload steps on codecov token presence

   Some repos may not upload to codecov for various reasons. Those repos
   won't set the code coverage token so conditionalize the upload steps
   on the token.

---

Will unblock https://github.com/microsoft/mu_rust_hid/pull/12