### PR TITLE
Multiple Updates to code coverage

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v8.0.0" %}
+{% set mu_devops = "v9.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -1,5 +1,5 @@
 ## @file
-# Azure Pipeline build file for a build using mu_devops..
+# Azure Pipeline build file for a build using mu_devops.
 #
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -1,5 +1,5 @@
 ## @file
-# Azure Pipeline build file for a build using mu_devops.
+# Azure Pipeline build file for a build using mu_devops..
 #
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -93,7 +93,6 @@ jobs:
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
-    calculate_code_coverage: ${{ parameters.calculate_code_coverage }}
     coverage_publish_target: ${{ parameters.coverage_publish_target }}
     do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
     do_non_ci_build: ${{ parameters.do_non_ci_build }}

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -45,7 +45,7 @@ parameters:
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string
-  default: 'ado' # 'ado', 'codecov'
+  default: 'ado' # 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -45,6 +45,10 @@ parameters:
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string
+  values:
+  - 'ado'
+  - 'codecov'
+  - ''
   default: 'ado' # 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -42,9 +42,6 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: calculate_code_coverage
-  displayName: Calculate Code Coverage From Unit Tests
-  default: false
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -35,14 +35,10 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: calculate_code_coverage
-  displayName: Calculate Code Coverage
-  type: boolean
-  default: false
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string
-  default: 'ado' # 'ado', 'codecov'
+  default: 'ado' # 'ado', 'codecov', ''
 - name: extra_post_build_steps
   displayName: Extra Post-Build Steps
   type: stepList
@@ -163,10 +159,7 @@ jobs:
         do_non_ci_build: ${{ parameters.do_non_ci_build }}
         do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
         do_pr_eval: ${{ parameters.do_pr_eval }}
-        ${{ if and(eq(parameters.calculate_code_coverage, true), eq(parameters.coverage_publish_target, 'codecov')) }}:
-          publish_coverage: true
-        ${{ else }}:
-          publish_coverage: false
+        coverage_publish_target: ${{ parameters.coverage_publish_target }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}
@@ -180,19 +173,3 @@ jobs:
           extra_build_args: CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE
         ${{ else }}:
           extra_build_args: ''
-
-- ${{ if eq(parameters.calculate_code_coverage, true) }}:
-  - job: PublishCoverage
-    dependsOn:
-    - ${{ each item in parameters.build_matrix }}:
-      - Build_${{ item.Key }}
-    condition: and(not(Canceled()), not(Failed()), eq( '${{ parameters.coverage_publish_target }}', 'ado'))
-
-    workspace:
-      clean: all
-
-    pool:
-      vmImage: 'windows-latest'
-
-    steps:
-      - template: ../Steps/PublishCodeCoverage.yml

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -181,18 +181,18 @@ jobs:
         ${{ else }}:
           extra_build_args: ''
 
-- ${{ if and(eq(parameters.calculate_code_coverage, true), eq(parameters.coverage_publish_target, 'ado')) }}:
-  - job: PublishCoverage
-    dependsOn:
-    - ${{ each item in parameters.build_matrix }}:
-      - Build_${{ item.Key }}
-    condition: and(not(Canceled()), not(Failed()))
+#- ${{ if and(eq(parameters.calculate_code_coverage, true), eq(parameters.coverage_publish_target, 'ado')) }}:
+- job: PublishCoverage
+  dependsOn:
+  - ${{ each item in parameters.build_matrix }}:
+    - Build_${{ item.Key }}
+  condition: and(not(Canceled()), not(Failed()), eq(parameters.coverage_publish_target, 'ado'))
 
-    workspace:
-      clean: all
+  workspace:
+    clean: all
 
-    pool:
-      vmImage: 'windows-latest'
+  pool:
+    vmImage: 'windows-latest'
 
-    steps:
-      - template: ../Steps/PublishCodeCoverage.yml
+  steps:
+    - template: ../Steps/PublishCodeCoverage.yml

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -181,18 +181,18 @@ jobs:
         ${{ else }}:
           extra_build_args: ''
 
-#- ${{ if and(eq(parameters.calculate_code_coverage, true), eq(parameters.coverage_publish_target, 'ado')) }}:
-- job: PublishCoverage
-  dependsOn:
-  - ${{ each item in parameters.build_matrix }}:
-    - Build_${{ item.Key }}
-  condition: and(not(Canceled()), not(Failed()), eq(parameters.coverage_publish_target, 'ado'))
+- ${{ if eq(parameters.calculate_code_coverage, true}}:
+  - job: PublishCoverage
+    dependsOn:
+    - ${{ each item in parameters.build_matrix }}:
+      - Build_${{ item.Key }}
+    condition: and(not(Canceled()), not(Failed()), eq(${{ parameters.coverage_publish_target }}, 'ado'))
 
-  workspace:
-    clean: all
+    workspace:
+      clean: all
 
-  pool:
-    vmImage: 'windows-latest'
+    pool:
+      vmImage: 'windows-latest'
 
-  steps:
-    - template: ../Steps/PublishCodeCoverage.yml
+    steps:
+      - template: ../Steps/PublishCodeCoverage.yml

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -169,7 +169,4 @@ jobs:
           self_host_agent: true
         ${{ else }}:
           self_host_agent: false
-        ${{ if eq(parameters.calculate_code_coverage, true) }}:
-          extra_build_args: CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE
-        ${{ else }}:
-          extra_build_args: ''
+        extra_build_args: CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -181,7 +181,7 @@ jobs:
         ${{ else }}:
           extra_build_args: ''
 
-- ${{ if eq(parameters.calculate_code_coverage, true}}:
+- ${{ if eq(parameters.calculate_code_coverage, true) }}:
   - job: PublishCoverage
     dependsOn:
     - ${{ each item in parameters.build_matrix }}:

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -186,7 +186,7 @@ jobs:
     dependsOn:
     - ${{ each item in parameters.build_matrix }}:
       - Build_${{ item.Key }}
-    condition: and(not(Canceled()), not(Failed()), eq(${{ parameters.coverage_publish_target }}, 'ado'))
+    condition: and(not(Canceled()), not(Failed()), eq( '${{ parameters.coverage_publish_target }}', 'ado'))
 
     workspace:
       clean: all

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -96,7 +96,7 @@ coverage data:
 
 - **MuDevOpsWrapper.yml** - This is the most user friendly way to perform Core CI. If extending this template, enabling
   code coverage is as simple as setting the parameter `coverage_publish_target` to 'ado' or 'codecov'. `Jobs/PrGate.yml`
-  and `Steps/PrGate.yml` use the same parameter name iwth the same outcome.
+  and `Steps/PrGate.yml` use the same parameter name with the same outcome.
 
 - **Steps/UploadCodeCoverage.yml** - This is the template to directly upload code coverage data. Set `upload_target` to
   'ado' or 'codecov' to upload. The `report_dir` is parameter used to specify the directory to recursivly look for

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -38,6 +38,8 @@ Table of Contents
 
 3. `Continuous Integration (CI)`_
 
+   - `Code Coverage`_
+
 4. `Conventions`_
 
 5. `Containers`_
@@ -84,6 +86,21 @@ Continuous Integration (CI)
 There are two broad categories of CI - Core CI and Platform CI. You may see these terms used in the repo.
   - **Core CI** - Focused on building and testing all packages in Edk2 without an actual target platform.
   - **Platform CI** - Focused on building a single target platform and confirming functionality on that platform.
+
+Code Coverage
+-------------
+
+mu_devops provides azure pipeline templates for uploading code coverage to the pipline currently executing, or directly
+to codecov.io for public github repositories that use azure pipelines. There are two supported ways to upload code
+coverage data:
+
+- **MuDevOpsWrapper.yml** - This is the most user friendly way to perform Core CI. If extending this template, enabling
+  code coverage is as simple as setting the parameter `coverage_publish_target` to 'ado' or 'codecov'. `Jobs/PrGate.yml`
+  and `Steps/PrGate.yml` use the same parameter name iwth the same outcome.
+
+- **Steps/UploadCodeCoverage.yml** - This is the template to directly upload code coverage data. Set `upload_target` to
+  'ado' or 'codecov' to upload. The `report_dir` is parameter used to specify the directory to recursivly look for
+  \*coverage.xml files to upload 
 
 Conventions
 ===========

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -99,7 +99,7 @@ coverage data:
   and `Steps/PrGate.yml` use the same parameter name with the same outcome.
 
 - **Steps/UploadCodeCoverage.yml** - This is the template to directly upload code coverage data. Set `upload_target` to
-  'ado' or 'codecov' to upload. The `report_dir` is parameter used to specify the directory to recursivly look for
+  'ado' or 'codecov' to upload. `report_dir` is parameter used to specify the directory to recursivly look for
   \*coverage.xml files to upload 
 
 Conventions

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -171,7 +171,7 @@ steps:
     parameters:
       report_dir: 'Build/${{ pkg }}'
       flag: ${{ pkg }}
-      target: ${{ parameters.coverage_publish_target }}
+      upload_target: ${{ parameters.coverage_publish_target }}
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -57,7 +57,7 @@ parameters:
 - name: coverage_publish_target
   displayName: Publish Code coverage to ado, codecov, or nothing
   type: string # 'ado', 'codecov', ''
-  default: false
+  default: ''
 - name: extra_build_args
   displayName: Extra Build Command Arguments
   type: string

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -54,9 +54,9 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: publish_coverage
-  displayName: Publish Code Coverage to codecov.io
-  type: boolean
+- name: coverage_publish_target
+  displayName: Publish Code coverage to ado, codecov, or nothing
+  type: string # 'ado', 'codecov', ''
   default: false
 - name: extra_build_args
   displayName: Extra Build Command Arguments
@@ -166,12 +166,12 @@ steps:
       script: stuart_ci_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
     condition: and(gt(variables.pkg_count, 0), succeeded())
 
-- ${{ if eq(parameters.publish_coverage, true) }}:
-  - ${{ each pkg in split(parameters.build_pkgs, ',') }}:
-    - template: UploadCodeCoverage.yml
-      parameters:
-        report_dir: 'Build/${{ pkg }}'
-        flag: ${{ pkg }}
+- ${{ each pkg in split(parameters.build_pkgs, ',') }}:
+  - template: UploadCodeCoverage.yml
+    parameters:
+      report_dir: 'Build/${{ pkg }}'
+      flag: ${{ pkg }}
+      target: ${{ parameters.coverage_publish_target }}
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -42,8 +42,10 @@ steps:
       REPORT_DIR = os.environ['REPORT_DIR']
 
       print(f'##vso[task.setvariable variable=upload_target]{UPLOAD_TARGET}')
-      print(f'Code Coveragte Upload Target: {UPLOAD_TARGET}')
+      print(f'Code Coverage Upload Target: {UPLOAD_TARGET}')
+
       print(f'##vso[task.setvariable variable=coverage_file_count]{len(list(Path(REPORT_DIR).rglob("*coverage.xml")))}')
+      print(f'Code Coverage Files: {list(Path(REPORT_DIR).rglob("*coverage.xml"))}')
 #
 # Steps to upload to Azure DevOps
 #
@@ -147,7 +149,8 @@ steps:
         process = subprocess.Popen(
           cmd,
           stdout=subprocess.PIPE,
-          stderr=subprocess.PIPE)
+          stderr=subprocess.PIPE,
+          shell=True)
         output, error = process.communicate()
         print(f"##[debug]{output.decode('utf-8')}")
         if process.returncode != 0:

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -24,7 +24,7 @@ parameters:
 - name: upload_target
   displayName: Upload Target
   type: string
-  default: 'ado'
+  default: 'codecov'
 
 steps:
 - task: PythonScript@0

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,12 +27,23 @@ parameters:
   default: 'ado'
 
 steps:
-- script: |
-    echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}"
-    echo "Code Coverage Upload Target: ${{ parameters.upload_target }}"
-    $coverage_file_count=(Get-ChildItem $(Build.ArtifactStagingDirectory)/coverage/ -Recurse -Include *_coverage.xml).count
-    Write-Host echo "##vso[task.setvariable variable=coverage_file_count]$coverage_file_count"
+- task: PythonScript@0
   displayName: Detect Code Coverage Target and Files
+  env:
+    UPLOAD_TARGET: ${{ parameters.upload_target }}
+    REPORT_DIR: ${{ parameters.report_dir }}
+  inputs:
+    scriptSource: inline
+    script: |
+      import os
+      from pathlib import Path
+
+      UPLOAD_TARGET = os.environ['UPLOAD_TARGET']
+      REPORT_DIR = os.environ['REPORT_DIR']
+
+      print(f'##vso[task.setvariable variable=upload_target]{UPLOAD_TARGET}')
+      print('Code Coveragte Upload Target: '{UPLOAD_TARGET}')
+      print(f'##vso[task.setvariable variable=coverage_file_count]{len(list(Path(REPORT_DIR).rglob("*coverage.xml")))}')
 #
 # Steps to upload to Azure DevOps
 #

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -32,22 +32,22 @@ steps:
 # Steps to upload to Azure DevOps
 #
 - task: PublishCodeCoverageResults@2
-  displayName: "AzureDevops: Publish Code Coverage"
+  displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition: eq( '${{ parameters.upload_target }}', 'ado')
+  condition:  ${{ eq( parameters.upload_target, 'ado') }}
 #
 # All Steps to upload to codecov.io
 #
 - ${{ if eq(parameters.install_dependencies, true) }}:
   - script: |
       pip install requests
-    displayName: "CodeCov: Install Python Dependencies for Codecov Uploader"
-    condition: eq( '${{ parameters.upload_target }}', 'codecov')
+    displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
+    condition: ${{ eq( parameters.upload_target, 'codecov') }}
 
 - task: PythonScript@0
-  displayName: "CodeCov: Download and Verify Codecov Uploader"
-  condition: eq( '${{ parameters.upload_target }}', 'codecov')
+  displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
+  condition:  ${{ eq( parameters.upload_target, 'codecov') }}
   inputs:
     scriptSource: inline
     script: |
@@ -106,8 +106,8 @@ steps:
         os.chmod(filename, 0o755)
 
 - task: PythonScript@0
-  displayName: "CodeCov: Upload Results ${{ parameters.flag }}"
-  condition: eq( '${{parameters.upload_target }}', 'codecov')
+  displayName: "Coverage CodeCov ${{ parameters.flag }}: Upload Results"
+  condition:  ${{ eq( parameters.upload_target, 'codecov') }}
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -35,7 +35,7 @@ steps:
   displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition:  eq( parameters.upload_target, 'ado')
+  condition:  eq( '${{ parameters.upload_target }}' , 'ado')
 #
 # All Steps to upload to codecov.io
 #
@@ -43,11 +43,11 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: eq( parameters.upload_target, 'codecov')
+    condition: eq( '${{ parameters.upload_target }}' , 'codecov')
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
-  condition:  eq( parameters.upload_target, 'codecov')
+  condition:  eq( '${{ parameters.upload_target }}' , 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -107,7 +107,7 @@ steps:
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Upload Results"
-  condition:  eq( parameters.upload_target, 'codecov')
+  condition:  eq( '${{ parameters.upload_target }}' , 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -131,8 +131,7 @@ steps:
         cmd = f'{UPLOAD_CMD} -f {cov_file} -Z'
         if COV_FLAG:
           cmd += f' -F {COV_FLAG}'
-        
-        print("##[debug]Running: " + cmd")
+
         process = subprocess.Popen(
           cmd,
           stdout=subprocess.PIPE,

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -21,15 +21,21 @@ parameters:
   displayName: Install Pypi Dependencies
   type: boolean
   default: true
+- name: condition
+  displayName: Condition
+  type: boolean
+  default: true
 
 steps:
 - ${{ if eq(parameters.install_dependencies, true) }}:
   - script: |
       pip install requests
     displayName: Install Python Dependencies for Codecov Uploader
+    condition: eq( '${{parameters.condition }}', 'codecov')
 
 - task: PythonScript@0
   displayName: Download and Verify Codecov Uploader
+  condition: eq( '${{parameters.condition }}', 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -89,6 +95,7 @@ steps:
 
 - task: PythonScript@0
   displayName: Run Codecov Uploader ${{ parameters.flag }}
+  condition: eq( '${{parameters.condition }}', 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,7 +27,7 @@ parameters:
   default: 'ado'
 
 steps:
-- script: echo ${{ parameters.upload_target }}
+- script: echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}
 #
 # Steps to upload to Azure DevOps
 #
@@ -35,7 +35,7 @@ steps:
   displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition:  eq( '${{ parameters.upload_target }}' , 'ado')
+  condition:  eq( '${{ variables.upload_target }}' , 'ado')
 #
 # All Steps to upload to codecov.io
 #
@@ -43,11 +43,11 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: eq( '${{ parameters.upload_target }}' , 'codecov')
+    condition: eq('${{ parameters.upload_target }}','codecov')
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
-  condition:  eq( '${{ parameters.upload_target }}' , 'codecov')
+  condition:  eq(variables.upload_target, 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -107,7 +107,7 @@ steps:
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Upload Results"
-  condition:  eq( '${{ parameters.upload_target }}' , 'codecov')
+  condition:  eq(variables['upload_target'] , 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,7 +27,7 @@ parameters:
   default: 'ado'
 
 steps:
-- script: echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}
+- script: echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}"
 #
 # Steps to upload to Azure DevOps
 #

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -42,7 +42,7 @@ steps:
       REPORT_DIR = os.environ['REPORT_DIR']
 
       print(f'##vso[task.setvariable variable=upload_target]{UPLOAD_TARGET}')
-      print('Code Coveragte Upload Target: {UPLOAD_TARGET}')
+      print(f'Code Coveragte Upload Target: {UPLOAD_TARGET}')
       print(f'##vso[task.setvariable variable=coverage_file_count]{len(list(Path(REPORT_DIR).rglob("*coverage.xml")))}')
 #
 # Steps to upload to Azure DevOps

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,11 +27,9 @@ steps:
   - script: |
       pip install requests
     displayName: Install Python Dependencies for Codecov Uploader
-    condition: ne(variables['CODECOV_TOKEN'], '')
 
 - task: PythonScript@0
   displayName: Download and Verify Codecov Uploader
-  condition: ne(variables['CODECOV_TOKEN'], '')
   inputs:
     scriptSource: inline
     script: |
@@ -91,7 +89,6 @@ steps:
 
 - task: PythonScript@0
   displayName: Run Codecov Uploader ${{ parameters.flag }}
-  condition: ne(variables['CODECOV_TOKEN'], '')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}
@@ -109,11 +106,10 @@ steps:
       UPLOAD_CMD = os.environ['UPLOAD_CMD']
 
       for cov_file in Path(REPORT_DIR).rglob('*coverage.xml'):
-        params = f'{UPLOAD_CMD} -f {cov_file} -Z'
+        cmd = f'{UPLOAD_CMD} -f {cov_file} -Z'
         if COV_FLAG:
-          params += f' -F {COV_FLAG}'
+          cmd += f' -F {COV_FLAG}'
         
-        cmd = UPLOAD_CMD + " ".join(params)
         print("##[debug]Running: " + cmd")
         process = subprocess.Popen(
           cmd,

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -21,21 +21,21 @@ parameters:
   displayName: Install Pypi Dependencies
   type: boolean
   default: true
-- name: condition
-  displayName: Condition
-  type: boolean
-  default: true
+- name: upload_target
+  displayName: Upload Target
+  type: string
+  default: 'ado'
 
 steps:
 - ${{ if eq(parameters.install_dependencies, true) }}:
   - script: |
       pip install requests
     displayName: Install Python Dependencies for Codecov Uploader
-    condition: eq( '${{parameters.condition }}', 'codecov')
+    condition: eq( '${{parameters.upload_target }}', 'codecov')
 
 - task: PythonScript@0
   displayName: Download and Verify Codecov Uploader
-  condition: eq( '${{parameters.condition }}', 'codecov')
+  condition: eq( '${{parameters.upload_target }}', 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -95,7 +95,7 @@ steps:
 
 - task: PythonScript@0
   displayName: Run Codecov Uploader ${{ parameters.flag }}
-  condition: eq( '${{parameters.condition }}', 'codecov')
+  condition: eq( '${{parameters.upload_target }}', 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -32,8 +32,7 @@ steps:
     echo "Code Coverage Upload Target: ${{ parameters.upload_target }}"
     $coverage_file_count=(Get-ChildItem $(Build.ArtifactStagingDirectory)/coverage/ -Recurse -Include *_coverage.xml).count
     Write-Host echo "##vso[task.setvariable variable=coverage_file_count]$coverage_file_count"
-  displayName: Check For Coverage Files
-  displayName: Detect Code Coverage Target
+  displayName: Detect Code Coverage Target and Files
 #
 # Steps to upload to Azure DevOps
 #
@@ -49,7 +48,7 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: and(eq(variables['upload_target'] , 'ado'), gt(variables.coverage_file_count, 0))
+    condition: and(eq(variables['upload_target'] , 'codecov'), gt(variables.coverage_file_count, 0))
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -112,8 +112,11 @@ steps:
         params = f'{UPLOAD_CMD} -f {cov_file} -Z'
         if COV_FLAG:
           params += f' -F {COV_FLAG}'
+        
+        cmd = UPLOAD_CMD + " ".join(params)
+        print("##[debug]Running: " + cmd")
         process = subprocess.Popen(
-          [UPLOAD_CMD, params],
+          cmd,
           stdout=subprocess.PIPE,
           stderr=subprocess.PIPE)
         output, error = process.communicate()

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -35,7 +35,7 @@ steps:
   displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition:  ${{ eq( parameters.upload_target, 'ado') }}
+  condition:  eq( parameters.upload_target, 'ado')
 #
 # All Steps to upload to codecov.io
 #
@@ -43,11 +43,11 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: ${{ eq( parameters.upload_target, 'codecov') }}
+    condition: eq( parameters.upload_target, 'codecov')
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
-  condition:  ${{ eq( parameters.upload_target, 'codecov') }}
+  condition:  eq( parameters.upload_target, 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -107,7 +107,7 @@ steps:
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Upload Results"
-  condition:  ${{ eq( parameters.upload_target, 'codecov') }}
+  condition:  eq( parameters.upload_target, 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -42,7 +42,7 @@ steps:
       REPORT_DIR = os.environ['REPORT_DIR']
 
       print(f'##vso[task.setvariable variable=upload_target]{UPLOAD_TARGET}')
-      print('Code Coveragte Upload Target: '{UPLOAD_TARGET}')
+      print('Code Coveragte Upload Target: {UPLOAD_TARGET}')
       print(f'##vso[task.setvariable variable=coverage_file_count]{len(list(Path(REPORT_DIR).rglob("*coverage.xml")))}')
 #
 # Steps to upload to Azure DevOps

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -46,7 +46,7 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: eq('${{ parameters.upload_target }}','codecov')
+    condition: eq(variables['upload_target'] , 'ado')
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -30,6 +30,9 @@ steps:
 - script: |
     echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}"
     echo "Code Coverage Upload Target: ${{ parameters.upload_target }}"
+    $coverage_file_count=(Get-ChildItem $(Build.ArtifactStagingDirectory)/coverage/ -Recurse -Include *_coverage.xml).count
+    Write-Host echo "##vso[task.setvariable variable=coverage_file_count]$coverage_file_count"
+  displayName: Check For Coverage Files
   displayName: Detect Code Coverage Target
 #
 # Steps to upload to Azure DevOps
@@ -38,7 +41,7 @@ steps:
   displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition:  eq(variables['upload_target'] , 'ado')
+  condition:  and(eq(variables['upload_target'] , 'ado'), gt(variables.coverage_file_count, 0))
 #
 # All Steps to upload to codecov.io
 #
@@ -46,11 +49,11 @@ steps:
   - script: |
       pip install requests
     displayName: "Coverage CodeCov ${{ parameters.flag }}: Install Python Dependencies"
-    condition: eq(variables['upload_target'] , 'ado')
+    condition: and(eq(variables['upload_target'] , 'ado'), gt(variables.coverage_file_count, 0))
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
-  condition:  eq(variables['upload_target'] , 'codecov')
+  condition:  and(eq(variables['upload_target'] , 'codecov'), gt(variables.coverage_file_count, 0))
   inputs:
     scriptSource: inline
     script: |
@@ -110,7 +113,7 @@ steps:
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Upload Results"
-  condition:  eq(variables['upload_target'] , 'codecov')
+  condition:  and(eq(variables['upload_target'] , 'codecov'), gt(variables.coverage_file_count, 0))
   env:
     COV_FLAG: ${{ parameters.flag }}
     REPORT_DIR: ${{ parameters.report_dir }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -131,7 +131,6 @@ steps:
         cmd = f'{UPLOAD_CMD} -f {cov_file} -Z'
         if COV_FLAG:
           cmd += f' -F {COV_FLAG}'
-
         process = subprocess.Popen(
           cmd,
           stdout=subprocess.PIPE,

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,7 +27,10 @@ parameters:
   default: 'ado'
 
 steps:
-- script: echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}"
+- script: |
+    echo "##vso[task.setvariable variable=upload_target]${{ parameters.upload_target }}"
+    echo "Code Coverage Upload Target: ${{ parameters.upload_target }}"
+  displayName: Detect Code Coverage Target
 #
 # Steps to upload to Azure DevOps
 #
@@ -35,7 +38,7 @@ steps:
   displayName: "Coverage ADO ${{ parameters.flag }}: Publish"
   inputs:
     summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
-  condition:  eq( '${{ variables.upload_target }}' , 'ado')
+  condition:  eq(variables['upload_target'] , 'ado')
 #
 # All Steps to upload to codecov.io
 #
@@ -47,7 +50,7 @@ steps:
 
 - task: PythonScript@0
   displayName: "Coverage CodeCov ${{ parameters.flag }}: Download and Verify Codecov Uploader"
-  condition:  eq(variables.upload_target, 'codecov')
+  condition:  eq(variables['upload_target'] , 'codecov')
   inputs:
     scriptSource: inline
     script: |

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -27,15 +27,27 @@ parameters:
   default: 'ado'
 
 steps:
+- script: echo ${{ parameters.upload_target }}
+#
+# Steps to upload to Azure DevOps
+#
+- task: PublishCodeCoverageResults@2
+  displayName: "AzureDevops: Publish Code Coverage"
+  inputs:
+    summaryFileLocation: '${{ parameters.report_dir }}/**/*coverage.xml'
+  condition: eq( '${{ parameters.upload_target }}', 'ado')
+#
+# All Steps to upload to codecov.io
+#
 - ${{ if eq(parameters.install_dependencies, true) }}:
   - script: |
       pip install requests
-    displayName: Install Python Dependencies for Codecov Uploader
-    condition: eq( '${{parameters.upload_target }}', 'codecov')
+    displayName: "CodeCov: Install Python Dependencies for Codecov Uploader"
+    condition: eq( '${{ parameters.upload_target }}', 'codecov')
 
 - task: PythonScript@0
-  displayName: Download and Verify Codecov Uploader
-  condition: eq( '${{parameters.upload_target }}', 'codecov')
+  displayName: "CodeCov: Download and Verify Codecov Uploader"
+  condition: eq( '${{ parameters.upload_target }}', 'codecov')
   inputs:
     scriptSource: inline
     script: |
@@ -94,7 +106,7 @@ steps:
         os.chmod(filename, 0o755)
 
 - task: PythonScript@0
-  displayName: Run Codecov Uploader ${{ parameters.flag }}
+  displayName: "CodeCov: Upload Results ${{ parameters.flag }}"
   condition: eq( '${{parameters.upload_target }}', 'codecov')
   env:
     COV_FLAG: ${{ parameters.flag }}


### PR DESCRIPTION
This PR contains multiple updates to code coverage when executed via MuDevOpsWrapper.yml

1. Removed calculate_code_coverage - This was redundant, as `coverage_publish_target` could be used instead (by having it not set, or selecting codecov / ado
2. Updates all usage of `coverage_publish_target` to be condition of a step, rather than used in a compile time expression for adding / removing steps. This is to support setting the parameter via pipeline variables. This has the unfortunate side effect of the steps always being present in the pipeline build, just skipped, which is not as clean as before.
3. Updates ado code coverage uploads to be per-matrix-job by utilizing `PublishCodeCoverageResults@2` which can merge code coverage results. This resolves #267
4. Resolves #276 by passing the entire command to `subprocess.Popen` and passing `shell=True` to the same.
5. Adds information to the base Readme on code coverage.

[Build](https://dev.azure.com/projectmu/mu/_build/results?buildId=58501&view=results) verifies uploading to codecov works as expected
[Build](https://dev.azure.com/projectmu/mu/_build/results?buildId=58500&view=results) verifies uploading to ado works as expected
[Build](https://dev.azure.com/projectmu/mu/_build/results?buildId=58535&view=results) verifies not specifying a coverage target works as expected

# Breaking Change

`calculate_code_coverage` must be removed from any yaml file extending MuDevOpsWrapper.yml