### PR TITLE
MuDevOpsWrapper.yml: Bugfix bad value options

### DIFF
--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -45,7 +45,7 @@ parameters:
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string
-  default: 'ado', 'codecov', ''
+  default: 'ado' # 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -49,7 +49,7 @@ parameters:
   - 'ado'
   - 'codecov'
   - 'none'
-  default: 'ado' # 'ado', 'codecov', ''
+  default: 'ado'
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -48,7 +48,7 @@ parameters:
   values:
   - 'ado'
   - 'codecov'
-  - ''
+  - 'none'
   default: 'ado' # 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -45,11 +45,7 @@ parameters:
 - name: coverage_publish_target
   displayName: Code Coverage Publish Target
   type: string
-  values:
-  - 'ado'
-  - 'codecov'
-  - 'none'
-  default: 'ado'
+  default: 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean

--- a/.sync/azure_pipelines/MuDevOpsWrapper.yml
+++ b/.sync/azure_pipelines/MuDevOpsWrapper.yml
@@ -1,6 +1,8 @@
 ## @file
 # Azure Pipeline build file for a build using mu_devops.
 #
+# To upload coverage results, set `coverage_upload_target` to `ado` or `codecov`.
+#
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.
 #
@@ -42,10 +44,6 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: coverage_publish_target
-  displayName: Code Coverage Publish Target
-  type: string
-  default: 'ado' # 'ado', 'codecov', ''
 - name: container_build
   displayName: Flag for whether this repo should do stuart_setup
   type: boolean
@@ -93,7 +91,6 @@ jobs:
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
-    coverage_publish_target: ${{ parameters.coverage_publish_target }}
     do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
     do_non_ci_build: ${{ parameters.do_non_ci_build }}
     build_matrix: ${{ parameters.build_matrix }}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -35,10 +35,6 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: coverage_publish_target
-  displayName: Code Coverage Publish Target
-  type: string
-  default: 'ado' # 'ado', 'codecov', ''
 - name: extra_post_build_steps
   displayName: Extra Post-Build Steps
   type: stepList
@@ -159,7 +155,6 @@ jobs:
         do_non_ci_build: ${{ parameters.do_non_ci_build }}
         do_non_ci_setup: ${{ parameters.do_non_ci_setup }}
         do_pr_eval: ${{ parameters.do_pr_eval }}
-        coverage_publish_target: ${{ parameters.coverage_publish_target }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -1,6 +1,8 @@
 ## @file
 # Template file used to build supported packages.
 #
+# To upload coverage results, set `coverage_upload_target` to `ado` or `codecov`.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Copyright (c) 2020 - 2021, ARM Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -91,16 +91,9 @@ Code Coverage
 -------------
 
 mu_devops provides azure pipeline templates for uploading code coverage to the pipline currently executing, or directly
-to codecov.io for public github repositories that use azure pipelines. There are two supported ways to upload code
-coverage data:
-
-- **MuDevOpsWrapper.yml** - This is the most user friendly way to perform Core CI. If extending this template, enabling
-  code coverage is as simple as setting the parameter `coverage_publish_target` to 'ado' or 'codecov'. `Jobs/PrGate.yml`
-  and `Steps/PrGate.yml` use the same parameter name with the same outcome.
-
-- **Steps/UploadCodeCoverage.yml** - This is the template to directly upload code coverage data. Set `upload_target` to
-  'ado' or 'codecov' to upload. `report_dir` is parameter used to specify the directory to recursivly look for
-  \*coverage.xml files to upload 
+to codecov.io for public github repositories that use azure pipelines. No matter the yaml file you are using, whether
+it be `MuDevOpsWrapper.yml`, `Jobs/PrGate.yml`, `Steps/PrGate.yml` or `Steps/UploadCodeCoverage.yml` itself, the only a
+action that needs to be taken is to set an environment variable `coverage_upload_target` to ado or codecov.
 
 Conventions
 ===========

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -1,6 +1,8 @@
 ## @file
 # Azure Pipelines step template to build for a pull request.
 #
+# To upload coverage results, set `coverage_upload_target` to `ado` or `codecov`.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -167,7 +167,6 @@ steps:
     parameters:
       report_dir: 'Build/${{ pkg }}'
       flag: ${{ pkg }}
-      upload_target: $(coverage_publish_target)
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -54,10 +54,6 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
-- name: coverage_publish_target
-  displayName: Publish Code coverage to ado, codecov, or nothing
-  type: string # 'ado', 'codecov', ''
-  default: ''
 - name: extra_build_args
   displayName: Extra Build Command Arguments
   type: string
@@ -171,7 +167,7 @@ steps:
     parameters:
       report_dir: 'Build/${{ pkg }}'
       flag: ${{ pkg }}
-      upload_target: ${{ parameters.coverage_publish_target }}
+      upload_target: $(coverage_publish_target)
 
 # Potential post-build steps
 - ${{ parameters.extra_post_build_steps }}

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -21,16 +21,12 @@ parameters:
   displayName: Install Pypi Dependencies
   type: boolean
   default: true
-- name: upload_target
-  displayName: Upload Target
-  type: string
-  default: 'codecov'
 
 steps:
 - task: PythonScript@0
   displayName: Detect Code Coverage Target and Files
   env:
-    UPLOAD_TARGET: ${{ parameters.upload_target }}
+    UPLOAD_TARGET: ${{ variables.coverage_upload_target }}
     REPORT_DIR: ${{ parameters.report_dir }}
   inputs:
     scriptSource: inline

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -1,6 +1,9 @@
 ## @file
 # Azure Pipelines step template upload code coverage to codecov.io
 #
+# Set `coverage_upload_target` to `codecov` or `ado` rather than passing it
+# as a parameter to this template.
+#
 # Follows the codecov.io documentation for uploading code coverage reports:
 # https://docs.codecov.com/docs/codecov-uploader
 #

--- a/Steps/UploadCodeCoverage.yml
+++ b/Steps/UploadCodeCoverage.yml
@@ -26,7 +26,7 @@ steps:
 - task: PythonScript@0
   displayName: Detect Code Coverage Target and Files
   env:
-    UPLOAD_TARGET: ${{ variables.coverage_upload_target }}
+    UPLOAD_TARGET: $(coverage_upload_target)
     REPORT_DIR: ${{ parameters.report_dir }}
   inputs:
     scriptSource: inline


### PR DESCRIPTION
the `values` config does not work as variables are not evaluated until the step runs, so what actually gets passed and verified against the `values` config ends up being the string `$(variable_name)`, which always fails as we were saying the value could only be "ado" or "codecov" or ""

This PR updates all yaml files to no longer pass the environment variable as a parameter from `MuDevOpsWrapper` -> `Jobs/PrGate` -> `Steps/PrGate` -> `UploadCodeCoverage` and instead uses the environment variable directly in `UploadCodeCoverage` All aforementioned yaml files have been updated with documentation on how to generate code coverage.