### PR TITLE
Start file sync for secureboot_objects repo

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -79,6 +79,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # CI Configuration - Markdown Lint - Mu Documentation Repo Settings
   - files:
@@ -124,6 +125,7 @@ group:
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # dependabot - Track GitHub Actions, PIP Modules, and Git Submodules
   - files:
@@ -171,6 +173,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # GitHub Templates - Issues
 #
@@ -195,6 +198,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # GitHub Templates - Licensing - Project Mu License
   - files:
@@ -259,6 +263,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Apply Labels
   - files:
@@ -448,6 +453,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Mark Stale Issues and Pull Requests (Mu DevOps Adjustment)
 # Prevents the reusable workflow file from being overwritten by the leaf workflow

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -173,7 +173,6 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
-      microsoft/secureboot_objects
 
 # GitHub Templates - Issues
 #
@@ -263,7 +262,6 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
-      microsoft/secureboot_objects
 
 # Leaf Workflow - Apply Labels
   - files:
@@ -406,6 +404,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Label Sync
   - files:
@@ -430,6 +429,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Mark Stale Issues and Pull Requests
   - files:
@@ -508,6 +508,7 @@ group:
       microsoft/mu_feature_uefi_variable
       microsoft/mu_rust_hid
       microsoft/mu_tiano_platforms
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Release Draft
 # Note: This group has two files synced that allow separate configuration for
@@ -560,6 +561,7 @@ group:
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
       microsoft/mu_tiano_plus
+      microsoft/secureboot_objects
 
 # Leaf Workflow - Submodule Release Update
   - files:


### PR DESCRIPTION
Adding a first pass of filesync for the secureboot_objects repo. 

@makubacki @Flickdm 
Please verify that all necessary files are being sycned in this PR.