### PR TITLE
Bump setup-python action from v4 to v5 in sync files

### DIFF
--- a/.github/actions/submodule-release-updater/action.yml
+++ b/.github/actions/submodule-release-updater/action.yml
@@ -32,7 +32,7 @@ runs:
 
   steps:
     - name: Set up Python Environment
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
 

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -127,7 +127,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
@@ -92,7 +92,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
         cache: 'pip'


### PR DESCRIPTION
Updates the sync files to use v5 so they will match the latest files
updated by dependabot in the synced repo. Also updates the version in
the file in the submodule-release-updater action.