### PR TITLE
.sync/workflows/leaf: CodeQL workflow changes for upload-artifact v4

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -275,10 +275,10 @@ jobs:
       run: stuart_setup -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Setup Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: (success() || failure()) && steps.get_platform_info.outputs.setup_supported == 'true'
       with:
-        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Logs
+        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Setup-Log
         path: |
           **/SETUPLOG.txt
           retention-days: 7
@@ -291,10 +291,10 @@ jobs:
       run: stuart_ci_setup -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload CI Setup Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: (success() || failure()) && steps.get_platform_info.outputs.ci_setup_supported == 'true'
       with:
-        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Logs
+        name: ${{ steps.get_platform_info.outputs.pkg_name }}-CI-Setup-Log
         path: |
           **/CISETUP.txt
           retention-days: 7
@@ -306,10 +306,10 @@ jobs:
       run: stuart_update -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Update Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Logs
+        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Update-Log
         path: |
           **/UPDATE_LOG.txt
         retention-days: 7
@@ -424,10 +424,10 @@ jobs:
         delete_dirs(build_path)
 
     - name: Upload Build Logs As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Logs
+        name: ${{ steps.get_platform_info.outputs.pkg_name }}-Build-Logs
         path: |
           **/BUILD_REPORT.TXT
           **/OVERRIDELOG.TXT
@@ -455,7 +455,7 @@ jobs:
             print(f'sarif_file_path={sarif_path}', file=fh)
 
     - name: Upload CodeQL Results (SARIF) As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.get_platform_info.outputs.pkg_name }}-CodeQL-SARIF
         path: ${{ steps.env_data.outputs.sarif_file_path }}

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -226,10 +226,10 @@ jobs:
       run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Setup Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.setup_supported == 'true'
       with:
-        name: ${{ matrix.package }}-Logs
+        name: ${{ matrix.package }}-Setup-Log
         path: |
           **/SETUPLOG.txt
           retention-days: 7
@@ -240,10 +240,10 @@ jobs:
       run: stuart_ci_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload CI Setup Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.ci_setup_supported == 'true'
       with:
-        name: ${{ matrix.package }}-Logs
+        name: ${{ matrix.package }}-CI-Setup-Log
         path: |
           **/CISETUP.txt
           retention-days: 7
@@ -253,10 +253,10 @@ jobs:
       run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Update Log As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: ${{ matrix.package }}-Logs
+        name: ${{ matrix.package }}-Update-Log
         path: |
           **/UPDATE_LOG.txt
         retention-days: 7
@@ -367,10 +367,10 @@ jobs:
         delete_dirs(build_path)
 
     - name: Upload Build Logs As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: ${{ matrix.package }}-Logs
+        name: ${{ matrix.package }}-Build-Logs
         path: |
           **/BUILD_REPORT.TXT
           **/OVERRIDELOG.TXT
@@ -398,7 +398,7 @@ jobs:
             print(f'sarif_file_path={sarif_path}', file=fh)
 
     - name: Upload CodeQL Results (SARIF) As An Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.package }}-CodeQL-SARIF
         path: ${{ steps.env_data.outputs.sarif_file_path }}


### PR DESCRIPTION
Two key new restrictions:

1. No more than 10 artifacts per job in a workflow run.
2. It is no longer possible to upload to the same named artifact
   multiple times.

These workflows can easily split their artifacts up under the 10
artifact limit while also not uploading to the same named artifact
in the process.

---

Tested:

- `codeql.yml` - [Mu Basecore Action Run 7258088601](https://github.com/makubacki/mu_basecore/actions/runs/7258088601)
- `codeql-platform.yml` - [Mu Tiano Platforms Action Run 7257959608](https://github.com/makubacki/mu_tiano_platforms/actions/runs/7257959608)