### PR TITLE
Introduce extra_build_args to Jobs/PrGate.yml. Move extra_install_steps to after stuart_update call. 

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -37,6 +37,10 @@ parameters:
   displayName: Perform Stuart PR Evaluation
   type: boolean
   default: true
+- name: extra_build_args
+  displayName: Extra Build Command Arguments
+  type: string
+  default: 'CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE'
 - name: extra_post_build_steps
   displayName: Extra Post-Build Steps
   type: stepList
@@ -166,4 +170,4 @@ jobs:
           self_host_agent: true
         ${{ else }}:
           self_host_agent: false
-        extra_build_args: CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE
+        extra_build_args: ${{ parameters.extra_build_args}}

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -170,4 +170,4 @@ jobs:
           self_host_agent: true
         ${{ else }}:
           self_host_agent: false
-        extra_build_args: ${{ parameters.extra_build_args}}
+        extra_build_args: ${{ parameters.extra_build_args }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -123,12 +123,6 @@ steps:
 - ${{ if eq(parameters.install_tools, true) }}:
   - template: InstallCoverageTools.yml
 
-# Potential Extra steps
-- ${{ if eq(parameters.self_host_agent, false) }}:
-  - ${{ parameters.extra_install_step }}
-- ${{ else }}:
-  - bash: echo "##[warning]A self-hosted agent build requested extra install steps. Those are not supported right now."
-
 # Build repo
 - ${{ if eq(parameters.do_ci_setup, true) }}:
   - task: CmdLine@2
@@ -149,6 +143,12 @@ steps:
   inputs:
     script: stuart_update -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
+
+# Potential Extra steps
+- ${{ if eq(parameters.self_host_agent, false) }}:
+  - ${{ parameters.extra_install_step }}
+- ${{ else }}:
+  - bash: echo "##[warning]A self-hosted agent build requested extra install steps. Those are not supported right now."
 
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@2


### PR DESCRIPTION
extra_install_step is moved to after stuart_update.

extra_install_steps can be used to pass a call to another stuart_update to include the --codeql parameter.