### PR TITLE
.sync/workflows/leaf/codeql.yml: Update CodeQL plugin from .pytool to BaseTools

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -324,7 +324,9 @@ jobs:
         from pathlib import Path
 
         # Find the plugin directory that contains the CodeQL plugin
-        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
+        if not plugin_dir:
+          plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
 
         # This should only be found once
         if len(plugin_dir) == 1:

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -271,7 +271,9 @@ jobs:
         from pathlib import Path
 
         # Find the plugin directory that contains the CodeQL plugin
-        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
+        if not plugin_dir:
+          plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
 
         # This should only be found once
         if len(plugin_dir) == 1:


### PR DESCRIPTION
The CodeQL plugin moved from .pytool to BaseTools in the Mu Basecore 202311 update. This change first looks for the plugin in BaseTools and falls back to the prior .pytool location if it is not found for backward compatibility with some earlier release branches that have not picked up the change.

Eventually, the .pytool fallback can be removed.

---

Issue to track removal of the fallback: https://github.com/microsoft/mu_devops/issues/300