### PR TITLE
Fix issue with .pytool/Plugin removal which was introduced with the latest codeql.yml change.

### DIFF
--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -352,8 +352,8 @@ jobs:
         import shutil
         from pathlib import Path
 
-        # Only this plugin is needed for CodeQL
-        plugins_to_keep = ['CompilerPlugin']
+        # Only these two plugins are needed for CodeQL
+        plugins_to_keep = ['CodeQL', 'CompilerPlugin']
 
         plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()
         if plugin_dir.is_dir():


### PR DESCRIPTION
The latest codeql.yml change updated the cleanup step to find .pytool/Plugin folder directly instead of using a relevant path form the CodeQL plugin directory.

That change didn't take into account how all branches from release/202302 and older have the .pytool/Plugin version of CodeQL and was deleting all plugins in .pytool besides CompilerPlugin. This change excludes the CodeQL plugin if it exists as well.