### PR TITLE
pip: Sync core stuart requirements

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -621,3 +621,21 @@ group:
       microsoft/mu_basecore
       microsoft/mu_plus
       microsoft/mu_tiano_platforms
+
+# Pip - Stuart pip requirements
+  - files:
+    - source: .sync/pytool/requirements.txt
+      dest: .pytool/requirements.txt
+    repos: |
+      microsoft/mu_basecore
+      microsoft/mu_common_intel_min_platform
+      microsoft/mu_feature_dfci
+      microsoft/mu_plus
+      microsoft/mu_silicon_arm_tiano
+      microsoft/mu_silicon_intel_tiano
+      microsoft/mu_tiano_platforms
+      microsoft/mu_tiano_plus
+      microsoft/mu_feature_config
+      microsoft/mu_oem_sample
+      microsoft/mu_feature_ipmi
+      microsoft/mu_feature_mm_supv

--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -101,3 +101,12 @@ updates:
       - "type:dependencies"
       - "type:dependabot"
     rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: edk2-pytool-library
+      - dependency-name: edk2-pytool-extensions
+      - dependency-name: edk2-basetools
+      - dependency-name: antlr4-python3-runtime
+      - dependency-name: regex
+      - dependency-name: lcov-cobertura
+      - dependency-name: pygount
+      - dependency-name: toml

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -71,3 +71,12 @@ updates:
       - "type:dependencies"
       - "type:dependabot"
     rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: edk2-pytool-library
+      - dependency-name: edk2-pytool-extensions
+      - dependency-name: edk2-basetools
+      - dependency-name: antlr4-python3-runtime
+      - dependency-name: regex
+      - dependency-name: lcov-cobertura
+      - dependency-name: pygount
+      - dependency-name: toml

--- a/.sync/pytool/requirements.txt
+++ b/.sync/pytool/requirements.txt
@@ -1,0 +1,28 @@
+## @file
+# EDK II Python PIP requirements file
+#
+# This file provides the list of python components to install using PIP to
+# support the usage of stuart invocables
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# https://pypi.org/project/pip/
+# https://pip.pypa.io/en/stable/user_guide/#requirements-files
+# https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+# https://www.python.org/dev/peps/pep-0440/#version-specifiers
+##
+edk2-pytool-library==0.20.0
+edk2-pytool-extensions~=0.27.0
+edk2-basetools==0.1.49
+antlr4-python3-runtime==4.13.1
+regex
+lcov-cobertura==2.0.2
+pygount==1.6.1
+toml==0.10.2


### PR DESCRIPTION
**Note**: I plan on this being new functionality for 202311 and should not be merged (if accepted) until then.

## Description

There are multiple core pip packages required for stuart to work (both for the invocable itself, and the core plugins).  This commit adds a requirements.txt file to the .pytool directory to sync these requirements across all repositories using stuart.

Repositories should not pip install this file directly, but instead link against it in their own requirements file using `-r .pytool/requirements.txt`. They should still add repository specific requirements to their own requirements file.

Adds packages to the ignore list of dependabot so that it does not create PRs for dependencies in `.pytool/requirements.txt`

The main benefit of this change is to allow multiple requirements to be updated at the same time, in a single PR, to reduce churn and total PRs necessary.

## Example

mu_feature_config
```
.
├── .pytool
│      ├── requirements.txt (sync'd)
├── pip-requirements.txt
```

pip-requirements.txt
```
-r .pytool/requirements.txt
pywin32==306; sys_platform == 'win32
```

final command (unchanged)
`pip install --upgrade -r pip-requirements.txt`