### PR TITLE
workflows: Add permissions.

### DIFF
--- a/.github/workflows/AutoMerger.yml
+++ b/.github/workflows/AutoMerger.yml
@@ -17,6 +17,11 @@ jobs:
     name: Merge
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
     # The action cannot take multiple authors right now, so call with each author
     # separately.
     strategy:

--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -21,6 +21,11 @@ jobs:
     name: Repo File Sync
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -15,9 +15,11 @@ jobs:
   adjust-labels:
     name: Adjust Issue Labels
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       issues: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -15,6 +15,9 @@ jobs:
   adjust-labels:
     name: Adjust Issue Labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/IssueTriager.yml
+++ b/.github/workflows/IssueTriager.yml
@@ -24,6 +24,9 @@ jobs:
     strategy:
       matrix:
         template: [ bug_report.yml, documentation_request.yml, feature_request.yml ]
+    
+    permissions:
+      issues: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -24,6 +24,8 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
     steps:
       - name: Sync Labels

--- a/.github/workflows/LabelSyncer.yml
+++ b/.github/workflows/LabelSyncer.yml
@@ -24,6 +24,7 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
+
     permissions:
       issues: write
 

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -31,6 +31,9 @@ jobs:
   sync:
     name: Label Based on Messages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Apply Labels Based on PR File Paths

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -31,6 +31,7 @@ jobs:
   sync:
     name: Label Based on Messages
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -45,6 +45,7 @@ jobs:
   update_release_draft:
     name: Update Release Draft
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -45,6 +45,9 @@ jobs:
   update_release_draft:
     name: Update Release Draft
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Download Version Information

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.0.1" %}
+{% set mu_devops = "v9.0.2" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.0.2" %}
+{% set mu_devops = "v9.1.1" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202302" %}

--- a/.sync/workflows/leaf/auto-approve.yml
+++ b/.sync/workflows/leaf/auto-approve.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   approval_check:
+    permissions:
+      pull-requests: write
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
     uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/auto-approve.yml
+++ b/.sync/workflows/leaf/auto-approve.yml
@@ -25,8 +25,10 @@ on:
 
 jobs:
   approval_check:
+
     permissions:
       pull-requests: write
+
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
     uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -26,6 +26,10 @@ on:
 
 jobs:
   merge_check:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
     uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/auto-merge.yml
+++ b/.sync/workflows/leaf/auto-merge.yml
@@ -26,10 +26,12 @@ on:
 
 jobs:
   merge_check:
+
     permissions:
       contents: read
       pull-requests: write
       issues: write
+
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
     uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/issue-assignment.yml
+++ b/.sync/workflows/leaf/issue-assignment.yml
@@ -17,12 +17,12 @@ name: React to Issue Assignment
 on:
   issues:
     types: assigned
-  permissions:
-    issues: write
 
 jobs:
   apply:
+
     permissions:
       contents: read
       issues: write
+
     uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/issue-assignment.yml
+++ b/.sync/workflows/leaf/issue-assignment.yml
@@ -17,6 +17,8 @@ name: React to Issue Assignment
 on:
   issues:
     types: assigned
+  permissions:
+    issues: write
 
 jobs:
   apply:

--- a/.sync/workflows/leaf/issue-assignment.yml
+++ b/.sync/workflows/leaf/issue-assignment.yml
@@ -22,4 +22,7 @@ on:
 
 jobs:
   apply:
+    permissions:
+      contents: read
+      issues: write
     uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -33,4 +33,7 @@ on:
 
 jobs:
   apply:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: microsoft/mu_devops/.github/workflows/Labeler.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -14,7 +14,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-{% import '../../Version.njk' as sync_version -%}
+# {% import '../../Version.njk' as sync_version -%}
 
 name: Apply Issue and PR Labels
 

--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -14,7 +14,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-# {% import '../../Version.njk' as sync_version -%}
+{% import '../../Version.njk' as sync_version -%}
 
 name: Apply Issue and PR Labels
 
@@ -33,7 +33,9 @@ on:
 
 jobs:
   apply:
+
     permissions:
       contents: read
       pull-requests: write
+
     uses: microsoft/mu_devops/.github/workflows/Labeler.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/label-sync.yml
+++ b/.sync/workflows/leaf/label-sync.yml
@@ -26,6 +26,8 @@ on:
 
 jobs:
   sync:
+
     permissions:
       issues: write
+
     uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/label-sync.yml
+++ b/.sync/workflows/leaf/label-sync.yml
@@ -26,4 +26,6 @@ on:
 
 jobs:
   sync:
+    permissions:
+      issues: write
     uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/pull-request-formatting-validator.yml
+++ b/.sync/workflows/leaf/pull-request-formatting-validator.yml
@@ -23,9 +23,11 @@ on:
 jobs:
   validate_pr:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='

--- a/.sync/workflows/leaf/pull-request-formatting-validator.yml
+++ b/.sync/workflows/leaf/pull-request-formatting-validator.yml
@@ -23,6 +23,9 @@ on:
 jobs:
   validate_pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -29,8 +29,10 @@ on:
 
 jobs:
   draft:
+
     permissions:
       contents: write
       pull-requests: write
+
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@{{ sync_version.mu_devops }}
     secrets: inherit

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -29,5 +29,8 @@ on:
 
 jobs:
   draft:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@{{ sync_version.mu_devops }}
     secrets: inherit

--- a/.sync/workflows/leaf/scheduled-maintenance.yml
+++ b/.sync/workflows/leaf/scheduled-maintenance.yml
@@ -24,6 +24,9 @@ on:
 jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV

--- a/.sync/workflows/leaf/scheduled-maintenance.yml
+++ b/.sync/workflows/leaf/scheduled-maintenance.yml
@@ -24,9 +24,11 @@ on:
 jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
+
     permissions:
       pull-requests: write
       issues: write
+
     steps:
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV

--- a/.sync/workflows/leaf/stale.yml
+++ b/.sync/workflows/leaf/stale.yml
@@ -26,7 +26,9 @@ on:
 
 jobs:
   check:
+
     permissions:
       issues: write
       pull-requests: write
+
     uses: microsoft/mu_devops/.github/workflows/Stale.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/stale.yml
+++ b/.sync/workflows/leaf/stale.yml
@@ -26,4 +26,7 @@ on:
 
 jobs:
   check:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: microsoft/mu_devops/.github/workflows/Stale.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -24,6 +24,7 @@ jobs:
   repo_submodule_update:
     name: Check for Submodule Releases
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write

--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -24,6 +24,9 @@ jobs:
   repo_submodule_update:
     name: Check for Submodule Releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Update Submodules to Latest Release

--- a/.sync/workflows/leaf/triage-issues.yml
+++ b/.sync/workflows/leaf/triage-issues.yml
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-{% import '../../Version.njk' as sync_version -%}
+# {% import '../../Version.njk' as sync_version -%}
 
 name: Initial Triage for New Issue
 
@@ -20,7 +20,9 @@ on:
     types: [ opened ]
 
 jobs:
-  permissions:
-    issues: write
   triage:
+
+    permissions:
+      issues: write
+
     uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/triage-issues.yml
+++ b/.sync/workflows/leaf/triage-issues.yml
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-# {% import '../../Version.njk' as sync_version -%}
+{% import '../../Version.njk' as sync_version -%}
 
 name: Initial Triage for New Issue
 

--- a/.sync/workflows/leaf/triage-issues.yml
+++ b/.sync/workflows/leaf/triage-issues.yml
@@ -20,5 +20,7 @@ on:
     types: [ opened ]
 
 jobs:
+  permissions:
+    issues: write
   triage:
     uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@{{ sync_version.mu_devops }}


### PR DESCRIPTION
Add permissions to the workflows across mu_devops. This includes the workflows sync'd across repositories, and workflows used in mu_devops itself. 


With MU_BASECORE's Settings -> Code and automation -> Actions -> General -> Workflow permissions set to "Read repository contents and packages permissions" selected, I had no failures, with the following tested:

.github/workflows
- **AutoMerger.yml - Untested**
- FileSyncer.yml - Tested
- IssueAssignment.yml - Tested
- IssueTriager.yml - Tested
- LabelSyncer.yml - Tested
- Labeler.yml - Tested
- ReleaseDrafter.yml - Tested

.sync/workflows/leaf
- **auto-approve.yml - Untested**
- **auto-merge.yml - Untested**
- issue-assignment.yml - Tested through IssueAssignment.yml
- label-issues.yml - Tested through Labeler.yml
- label-sync.yml - Tested through LabelSyncer.yml
- pull-request-formatting-validator.yml - Tested Directly
- release-draft.yml - Tested through ReleaseDrafter.yml
- scheduled-maintenance.yml - Tested Directly
- stale.yml - Tested Directly
- **submodule-release-update.yml - Untested**
- triage-issues.yml - Tested