### PR TITLE
Update Version.njk for release

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.1" %}
+{% set mu_devops = "v9.1.2" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}


### PR DESCRIPTION
Updates the mu_devops version in Version.njk to 9.1.2 in preparation for a 9.1.2 release of mu_devops that will be sync'd.