### PR TITLE
Update container version in Version.njk

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202302" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:1082f35" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:16d82ba" %}
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.74.0" %}


### PR DESCRIPTION
Updates the container version to the newly built container, which uses rust toolchain version 1.74.0. 