### PR TITLE
.sync/workflows/codeql-platform: Update irrelevant plugin removal dir [Rebase & FF]

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -376,10 +376,32 @@ jobs:
       working-directory: "Z:"
       run: stuart_update -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
+    - name: Find pytool Plugin Directory
+      id: find_pytool_dir
+      shell: python
+      run: |
+        import os
+        import sys
+        from pathlib import Path
+
+        # Find the plugin directory that contains the Compiler plugin
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CompilerPlugin'))
+
+        # This should only be found once
+        if len(plugin_dir) == 1:
+            # If the directory is found get the parent Plugin directory
+            plugin_dir = str(plugin_dir[0].parent)
+
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'pytool_plugin_dir={plugin_dir}', file=fh)
+        else:
+            print("::error title=Workspace Error!::Failed to find Mu Basecore .pytool/Plugin directory!")
+            sys.exit(1)
+
     - name: Remove CI Plugins Irrelevant to CodeQL
       shell: python
       env:
-        CODEQL_PLUGIN_DIR: ${{ steps.find_dir.outputs.codeql_plugin_dir }}
+        PYTOOL_PLUGIN_DIR: ${{ steps.find_pytool_dir.outputs.pytool_plugin_dir }}
       run: |
         import os
         import shutil
@@ -388,7 +410,7 @@ jobs:
         # Only these two plugins are needed for CodeQL
         plugins_to_keep = ['CodeQL', 'CompilerPlugin']
 
-        plugin_dir = Path(os.environ['CODEQL_PLUGIN_DIR']).parent.absolute()
+        plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()
         if plugin_dir.is_dir():
             for dir in plugin_dir.iterdir():
                 if str(dir.stem) not in plugins_to_keep:

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -3,10 +3,15 @@
 # Any platform that supports the `--codeql` parameter will be built and the
 # results will be uploaded to GitHub Code Scanning.
 #
+# Note: Important: This file only works with "platform" builds. "CI" builds are
+#                  supported with the codeql.yml file.
+#
 # Note: This workflow only supports Windows as CodeQL CLI has confirmed issues running
 #       against edk2-style codebases on Linux (only tested on Ubuntu). Therefore, this
 #       workflow is written only for Windows but could easily be adapted to run on Linux
 #       in the future if needed (e.g. swap out "windows" with agent OS var value, etc.)
+#
+#       For details about the Linux issue see: https://github.com/github/codeql-action/issues/1338
 #
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.
@@ -323,7 +328,14 @@ jobs:
         import sys
         from pathlib import Path
 
-        # Find the plugin directory that contains the CodeQL plugin
+        #
+        # Find the plugin directory that contains the CodeQL plugin.
+        #
+        # Prior to Mu Basecore 202311, the CodeQL plugin was located in .pytool. After it
+        # is located in BaseTools. First check BaseTools, but consider .pytool as a backup
+        # for backward compatibility. The .pytool backup can be removed when no longer needed
+        # for supported branches.
+        #
         plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
         if not plugin_dir:
           plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
@@ -407,7 +419,14 @@ jobs:
         import shutil
         from pathlib import Path
 
-        # Only these two plugins are needed for CodeQL
+        # Only these two plugins are needed for CodeQL.
+        #
+        # CodeQL build time is reduced by removing other plugins that are not needed for the CodeQL
+        # build in the .pytool directory. The CompilerPlugin is required to compile code for CodeQL
+        # to extract results from and the CodeQL plugin is necessary to to analyze the results and
+        # build the CodeQL database from them. The CodeQL plugin should be in BaseTools moving forward
+        # but still might be in .pytool in older branches so it is kept here as an exception.
+        #
         plugins_to_keep = ['CodeQL', 'CompilerPlugin']
 
         plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -2,13 +2,15 @@
 #
 # Results are uploaded to GitHub Code Scanning.
 #
-# Note: Important: This file currently only works with "CI" builds. "Platform" builds can
-#                   be supported without much effort but that will be done in the future.
+# Note: Important: This file only works with "CI" builds. "Platform" builds are
+#                  supported with the codeql-platform.yml file.
 #
 # Note: This workflow only supports Windows as CodeQL CLI has confirmed issues running
 #       against edk2-style codebases on Linux (only tested on Ubuntu). Therefore, this
 #       workflow is written only for Windows but could easily be adapted to run on Linux
-#       in the future if needed (e.g. swap out "windows" with agent OS var value, etc.)
+#       in the future if needed (e.g. swap out "windows" with agent OS var value, etc.).
+#
+#       For details about the Linux issue see: https://github.com/github/codeql-action/issues/1338
 #
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.
@@ -270,7 +272,14 @@ jobs:
         import sys
         from pathlib import Path
 
-        # Find the plugin directory that contains the CodeQL plugin
+        #
+        # Find the plugin directory that contains the CodeQL plugin.
+        #
+        # Prior to Mu Basecore 202311, the CodeQL plugin was located in .pytool. After it
+        # is located in BaseTools. First check BaseTools, but consider .pytool as a backup
+        # for backward compatibility. The .pytool backup can be removed when no longer needed
+        # for supported branches.
+        #
         plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
         if not plugin_dir:
           plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
@@ -352,7 +361,14 @@ jobs:
         import shutil
         from pathlib import Path
 
-        # Only these two plugins are needed for CodeQL
+        # Only these two plugins are needed for CodeQL.
+        #
+        # CodeQL build time is reduced by removing other plugins that are not needed for the CodeQL
+        # build in the .pytool directory. The CompilerPlugin is required to compile code for CodeQL
+        # to extract results from and the CodeQL plugin is necessary to to analyze the results and
+        # build the CodeQL database from them. The CodeQL plugin should be in BaseTools moving forward
+        # but still might be in .pytool in older branches so it is kept here as an exception.
+        #
         plugins_to_keep = ['CodeQL', 'CompilerPlugin']
 
         plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()


### PR DESCRIPTION
Two commits. One to prepare `codeql-platform.yml` for 202311 and the other
to expand contextual comments in both CodeQL workflow files.

---

**.sync/workflows/codeql-platform: Update irrelevant plugin removal dir**

Updates the directory used for irrelevant plugin removal in this
workflow to match codeql.yml which using the pytool directory rather
than the directory the CodeQL plugin is found in.

This is important because the CodeQL plugin moved from .pytool to
BaseTools in Mu release 202311 so the plugin dir needs to be fixed
rather than relative to the CodeQL plugin location.

---

**.sync/workflows/codeql: Add more inline documentation**

Updates and adds some additional comments to the CodeQL workflow
files to give better context.