### PR TITLE
Add pipeline to cache cargo binstall

### DIFF
--- a/.azurepipelines/GetCargoBinstall.yml
+++ b/.azurepipelines/GetCargoBinstall.yml
@@ -1,0 +1,54 @@
+## @file
+# Azure Pipeline to download Cargo Binstall and save it as a pipeline artifact that
+# can be accessed by other pipelines.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+schedules:
+# At 1:00 on Monday
+# https://crontab.guru/#0_1_*_*_1
+- cron: 0 1 * * 1
+  branches:
+    include:
+    - main
+  always: true
+
+jobs:
+- job: Update_Cargo_Binstall
+  displayName: Update Cargo Binstall
+
+  pool:
+    vmImage: windows-latest
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
+    fetchTags: false
+
+  - script: pip install requests --upgrade
+    displayName: Install and Upgrade pip Modules
+    condition: succeeded()
+
+  - task: PythonScript@0
+    displayName: Download and Stage Cargo Binstall
+    env:
+      BINARIES_DIR: "$(Build.BinariesDirectory)"
+      BINARY_NAME: "cargo-binstall"
+      DOWNLOAD_DIR: "$(Build.ArtifactStagingDirectory)"
+      REPO_URL: "https://api.github.com/repos/cargo-bins/cargo-binstall/releases"
+    inputs:
+      scriptSource: filePath
+      scriptPath: Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+      workingDirectory: $(Agent.BuildDirectory)
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Cargo Binstall
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(Build.BinariesDirectory)
+      ArtifactName: Binaries
+    condition: succeeded()

--- a/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+++ b/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
@@ -44,7 +44,7 @@ if len(releases) == 0:
 # Download assets
 for asset in releases[0]['assets']:
     name = asset['name'].lower()
-    if (("x86_64-pc-windows-msvc.full" in name or "x86_64-unknown-linux-gnu.full" in name)
+    if (("x86_64-pc-windows-msvc" in name or "x86_64-unknown-linux-gnu" in name)
        and asset['name'].endswith(('.zip', '.tar.gz', '.tgz'))):
         filepath = DOWNLOAD_DIR / asset['name']
         print(f"Downloading {asset['name']}...")

--- a/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
+++ b/Scripts/DownloadCargoBinaryFromGitHub/DownloadCargoBinaryFromGitHub.py
@@ -44,8 +44,8 @@ if len(releases) == 0:
 # Download assets
 for asset in releases[0]['assets']:
     name = asset['name'].lower()
-    if ("x86_64-pc-windows-msvc" in name or "x86_64-unknown-linux-gnu" in name
-       and asset['name'].endswith(('.zip', '.tar.gz'))):
+    if (("x86_64-pc-windows-msvc.full" in name or "x86_64-unknown-linux-gnu.full" in name)
+       and asset['name'].endswith(('.zip', '.tar.gz', '.tgz'))):
         filepath = DOWNLOAD_DIR / asset['name']
         print(f"Downloading {asset['name']}...")
         with requests.get(asset['browser_download_url'], stream=True) as r:
@@ -61,7 +61,7 @@ for filename in DOWNLOAD_DIR.iterdir():
     if filename.name.endswith('.zip'):
         with zipfile.ZipFile(filename, 'r') as zip_ref:
             zip_ref.extractall(extracted_dir)
-    elif filename.name.endswith('.tar.gz'):
+    elif filename.name.endswith(('.tar.gz', '.tgz')):
         with tarfile.open(filename, 'r:gz') as tar:
             tar.extractall(path=extracted_dir)
 


### PR DESCRIPTION
Adds a pipeline to cache cargo binstall.

Adds `.tgz` (short for `.tar.gz`) support to the DownloadCargoBinaryFromGitHub.py script. Also fixes a logic error in the conditional that decides which assets to download.

See successful pipeline run: https://dev.azure.com/projectmu/mu/_build/results?buildId=64211&view=logs&j=402df595-8a03-57d0-41e1-0654a1932349