### PR TITLE
Use cargo-binstall to sync rust tool versions

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.3" %}
+{% set mu_devops = "v9.1.5" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.2" %}
+{% set mu_devops = "v9.1.3" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}
@@ -41,3 +41,7 @@
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.74.0" %}
+
+{# Rust tool versions. #}
+{% set cargo_make = "0.37.9" %}
+{% set cargo_tarpaulin = "0.27.3" %}

--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -93,51 +93,41 @@ steps:
 
 - template: DownloadAzurePipelineArtifact.yml
   parameters:
-    task_display_name: Download Cargo Make (Windows)
+    task_display_name: Download Cargo Binstall (Windows)
     artifact_name: Binaries
-    azure_pipeline_def_id: 166
-    file_pattern: "**/cargo-make.exe"
+    azure_pipeline_def_id: 169
+    file_pattern: "**/cargo-binstall.exe"
     target_dir: "$(cargoBinPath)"
     target_os: "Windows_NT"
     work_dir: "$(Agent.TempDirectory)"
 
 - template: DownloadAzurePipelineArtifact.yml
   parameters:
-    task_display_name: Download Cargo Make (Linux)
+    task_display_name: Download Cargo Binstall (Linux)
     artifact_name: Binaries
-    azure_pipeline_def_id: 166
-    file_pattern: "**/cargo-make"
+    azure_pipeline_def_id: 169
+    file_pattern: "**/cargo-binstall"
     target_dir: "$(Agent.TempDirectory)"
     target_os: "Linux"
     work_dir: "$(Agent.TempDirectory)"
+
 - script: |
-    cp $AGENT_TEMPDIRECTORY/cargo-make /.cargo/bin
-  displayName: Copy cargo-make
+    cp $AGENT_TEMPDIRECTORY/cargo-binstall /.cargo/bin
+  displayName: Copy cargo-binstall
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-- template: DownloadAzurePipelineArtifact.yml
-  parameters:
-    task_display_name: Download Cargo Tarpaulin (Windows)
-    artifact_name: Binaries
-    azure_pipeline_def_id: 167
-    file_pattern: "**/cargo-tarpaulin.exe"
-    target_dir: "$(cargoBinPath)"
-    target_os: "Windows_NT"
-    work_dir: "$(Agent.TempDirectory)"
-
-- template: DownloadAzurePipelineArtifact.yml
-  parameters:
-    task_display_name: Download Cargo Tarpaulin (Linux)
-    artifact_name: Binaries
-    azure_pipeline_def_id: 167
-    file_pattern: "**/cargo-tarpaulin"
-    target_dir: "$(Agent.TempDirectory)"
-    target_os: "Linux"
-    work_dir: "$(Agent.TempDirectory)"
 - script: |
-    cp $AGENT_TEMPDIRECTORY/cargo-tarpaulin /.cargo/bin
-  displayName: Copy cargo-tarpaulin
+    sudo chmod +x /.cargo/bin/cargo-binstall
+  displayName: Make cargo-binstall executable
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+- script: |
+    cargo binstall -y cargo-make --version {{ sync_version.cargo_make_version }}
+  displayName: Install cargo-make
+
+- script: |
+    cargo binstall -y cargo-tarpaulin --version {{ sync_version.cargo_tarpaulin_version }}
+  displayName: Install cargo-tarpaulin
 
 - script: rustup component add rustfmt rust-src --toolchain {{ sync_version.rust_toolchain }}-$(rust_target_triple)
   displayName: rustup add rust-src

--- a/.sync/rust_config/rust-toolchain.toml
+++ b/.sync/rust_config/rust-toolchain.toml
@@ -2,3 +2,7 @@
 
 [toolchain]
 channel = "{{ sync_version.rust_toolchain }}"
+
+[tool]
+cargo-make = "{{ sync_version.cargo_make }}"
+cargo-tarpaulin = "{{ sync_version.cargo_tarpaulin }}"


### PR DESCRIPTION
Update RustSetupSteps to download cargo-binstall and use it to download all other rust tools. This is to make it easy for CI to pass the updated RustEnvironmentCheck (https://github.com/microsoft/mu_basecore/pull/737) by downloading the exact tool versions as specified in the rust-toolchain.toml file.