### PR TITLE
.sync/workflows/codeql: Use Version.njk cargo-make version

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -346,6 +346,7 @@ group:
   - files:
     - source: .sync/workflows/leaf/codeql.yml
       dest: .github/workflows/codeql.yml
+      template: true
     repos: |
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
@@ -367,6 +368,7 @@ group:
   - files:
     - source: .sync/workflows/leaf/codeql-platform.yml
       dest: .github/workflows/codeql-platform.yml
+      template: true
     repos: |
       microsoft/mu_tiano_platforms
 

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -22,6 +22,10 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
+{% import '../../Version.njk' as sync_version -%}
+
+{% raw %}
+
 name: "CodeQL - Platform"
 
 on:
@@ -147,25 +151,34 @@ jobs:
     - name: Install/Upgrade pip Modules
       run: pip install -r pip-requirements.txt --upgrade requests
 
+{% endraw %}
+
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       run: |
         import os
         import requests
+        import sys
 
         GITHUB_REPO = "sagiegurari/cargo-make"
-        API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
 
-        # Default value in case getting latest fails, cache will fall
-        # back on this version.
-        latest_cargo_make_version = "0.36.13"
-        response = requests.get(API_URL)
+        response = requests.get(api_url)
+        if response.status_code == 200:
+          build_release_id = response.json()["id"]
+        else:
+          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          sys.exit(1)
 
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
+
+        response = requests.get(api_url)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get latest cargo-make version!")
+          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'
 
@@ -173,6 +186,8 @@ jobs:
           print(f'cargo_bin_path={os.path.join(os.environ["USERPROFILE"], ".cargo", "bin")}', file=fh)
           print(f'cargo_make_cache_key={cache_key}', file=fh)
           print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
+
+{% raw %}
 
     - name: Attempt to Load cargo-make From Cache
       id: cargo_make_cache
@@ -519,3 +534,5 @@ jobs:
       shell: pwsh
       run: |
           subst Z: /D
+
+{% endraw %}

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -21,6 +21,10 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
+{% import '../../Version.njk' as sync_version -%}
+
+{% raw %}
+
 name: "CodeQL"
 
 on:
@@ -151,25 +155,34 @@ jobs:
             print(f'ci_setup_supported={str(ci_setup_supported).lower()}', file=fh)
             print(f'setup_supported={str(setup_supported).lower()}', file=fh)
 
+{% endraw %}
+
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       run: |
         import os
         import requests
+        import sys
 
         GITHUB_REPO = "sagiegurari/cargo-make"
-        API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
 
-        # Default value in case getting latest fails, cache will fall
-        # back on this version.
-        latest_cargo_make_version = "0.36.13"
-        response = requests.get(API_URL)
+        response = requests.get(api_url)
+        if response.status_code == 200:
+          build_release_id = response.json()["id"]
+        else:
+          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          sys.exit(1)
 
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
+
+        response = requests.get(api_url)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get latest cargo-make version!")
+          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'
 
@@ -177,6 +190,8 @@ jobs:
           print(f'cargo_bin_path={os.path.join(os.environ["USERPROFILE"], ".cargo", "bin")}', file=fh)
           print(f'cargo_make_cache_key={cache_key}', file=fh)
           print(f'cargo_make_version={latest_cargo_make_version}', file=fh)
+
+{% raw %}
 
     - name: Attempt to Load cargo-make From Cache
       id: cargo_make_cache
@@ -453,3 +468,5 @@ jobs:
         # Optional category for the results. Used to differentiate multiple results for one commit.
         # Each package is a separate category.
         category: ${{ matrix.package }}
+
+{% endraw %}


### PR DESCRIPTION
Most of the workflow can stay intact with GitHub caching working
as-is but the cargo-make version now needs to match the version that
is being synced to repos (i.e. matches rust-toolchain.toml).

---

Note: We can consider using cargo binstall in the future but right now
only cargo-make is needed, and it is simple to directly cache that binary
as-is with existing code.