### PR TITLE
codeql-platform.yml

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -456,7 +456,7 @@ jobs:
       env:
         RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
-      run: stuart_build -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
+      run: stuart_build -c ${{ matrix.build_file }} TARGET=DEBUG -a TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
     - name: Build Cleanup
       id: build_cleanup

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -456,7 +456,7 @@ jobs:
       env:
         RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
         STUART_CODEQL_PATH: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
-      run: stuart_build -c ${{ matrix.build_file }} TARGET=DEBUG -a TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
+      run: stuart_build -c ${{ matrix.build_file }} TARGET=DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
     - name: Build Cleanup
       id: build_cleanup


### PR DESCRIPTION
Removes the -t and -a command flags for the codeql-platform.yml workflow when executing stuart_build. Neither of these command line arguments are provided by the edk2_platform_build invocable. the target is set via TARGET=<value> for platforms, and the architecture is not set at all, as platforms hardcode the required architectures.

Sets the target via the expected way, TARGET=DEBUG.