### PR TITLE
Prevent rustup self update

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.6" %}
+{% set mu_devops = "v9.1.7" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}

--- a/.sync/azure_pipelines/RustSetupSteps.yml
+++ b/.sync/azure_pipelines/RustSetupSteps.yml
@@ -82,9 +82,13 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install {{ sync_version.rust_toolchain }}
-    rustup default {{ sync_version.rust_toolchain }}
+    rustup install --no-self-update {{ sync_version.rust_toolchain }}
   displayName: Install Rust {{ sync_version.rust_toolchain }} (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- script: |
+    rustup default {{ sync_version.rust_toolchain }}
+  displayName: Set Rust {{ sync_version.rust_toolchain }} (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -79,12 +79,9 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install --no-self-update 1.74.0
-  displayName: Install Rust 1.74.0 (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-- script: |
+    rustup install 1.74.0
     rustup default 1.74.0
-  displayName: Set Rust 1.74.0 (Windows)
+  displayName: Install Rust 1.74.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -79,7 +79,7 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install 1.74.0
+    rustup install --no-self-update 1.74.0
     rustup default 1.74.0
   displayName: Install Rust 1.74.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -80,8 +80,11 @@ steps:
 #
 - script: |
     rustup install --no-self-update 1.74.0
-    rustup default 1.74.0
   displayName: Install Rust 1.74.0 (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+- script: |
+    rustup default 1.74.0
+  displayName: Set Rust 1.74.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -79,9 +79,13 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install 1.74.0
-    rustup default 1.74.0
+    rustup install --no-self-update 1.74.0
   displayName: Install Rust 1.74.0 (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- script: |
+    rustup default 1.74.0
+  displayName: Set Rust 1.74.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade


### PR DESCRIPTION
By default `rusup` performs a self-update when installing a new rustc toolchain, Sometimes, the files are locked by windows, and the self update can fail as described here: https://github.com/rust-lang/rustup/issues/2441

Since this is a pipeline run, we have no need to update rustup, and can rely on the version provided by the runner. By disabling the self update, the file conflict `The process cannot access the file because it is being used by another process` no longer appears as seen in this test PR: https://dev.azure.com/projectmu/mu/_build/results?buildId=65795&view=results