### PR TITLE
.sync/Version.njk: Update to Rust 1.76

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -40,7 +40,7 @@
 {% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:16d82ba" %}
 
 {# The Rust toolchain version to use. #}
-{% set rust_toolchain = "1.74.0" %}
+{% set rust_toolchain = "1.76.0" %}
 
 {# Rust tool versions. #}
 {% set cargo_make = "0.37.9" %}


### PR DESCRIPTION
Routine update.

- https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html

Tested builds in Rust repos with 1.76.0.