### PR TITLE
Steps/SetupGitConfig.yml: Set auto.crlf to false in builds

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -75,6 +75,8 @@ steps:
     # Note: Depth cannot be limited if PR Eval is used. A pipeline may choose
     #       to use a shallow checkout if PR eval is not used.
 
+- template: SetupGitConfig.yml
+
 - template: SetupPythonPreReqs.yml
   parameters:
     install_python: ${{ parameters.install_tools }}

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -92,6 +92,8 @@ steps:
     fetchDepth: 0
     # Note: Depth cannot be limited if PR Eval is used
 
+- template: SetupGitConfig.yml
+
 - template: SetupPythonPreReqs.yml
   parameters:
     install_python: ${{ parameters.install_tools }}

--- a/Steps/SetupGitConfig.yml
+++ b/Steps/SetupGitConfig.yml
@@ -1,0 +1,22 @@
+## @file
+# Azure Pipelines step to setup Git config settings on the pipeline
+# used when building firmware code.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+parameters:
+- name: disable_autocrlf
+  displayName: Disable Git Auto CRLF
+  type: boolean
+  default: true
+
+steps:
+
+- ${{ if eq(parameters.disable_autocrlf, true) }}:
+  - task: CmdLine@2
+    displayName: Apply Git Config Settings
+    inputs:
+      script:
+        git config --system core.autocrlf false


### PR DESCRIPTION
Pipelines that build firmware come in through two entry points:

1. Steps/BuildPlatform.yml - Platform build (e.g. mu_tiano_platforms)
2. Steps/PrGate.yml - Core build (e.g. mu_basecore)

This change updates both paths to set core.autocrlf to false so line
endings are checked out as-is on Windows. This allows checks like the
LineEndingCheck to have similar results to Linux.

The change is placed in a dedicated file to make it easier to group
similar git config tweaks that might be required in pipelines for
flows that build firmware code in the future.