### PR TITLE
.sync/Version.njk: Update Mu repos to Mu DevOps v9.1.9

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.8" %}
+{% set mu_devops = "v9.1.9" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}


### PR DESCRIPTION
Changes since last release:
https://github.com/microsoft/mu_devops/compare/v9.1.8...v9.1.9

General release info: https://github.com/microsoft/mu_devops/releases

---

This change is needed to finishing syncing the Rust version update change.