### PR TITLE
Version.njk: Update Ubuntu 22 container for Rust 1.76.0

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202302" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:16d82ba" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:0e124c1" %}
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.76.0" %}


### PR DESCRIPTION
Only change is building with Rust 1.76.0 instead of Rust 1.74.0.