### PR TITLE
Steps/BuildPlatform.yml & Steps/PrGate.yml: Add parameter to install pip modules

### DIFF
--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -58,6 +58,10 @@ parameters:
   displayName: Install Build Tools
   type: boolean
   default: true
+- name: install_pip_modules
+  displayName: Install PIP Modules
+  type: boolean
+  default: true
 - name: tool_chain_tag
   displayName: Tool Chain (e.g. VS2022)
   type: string
@@ -78,6 +82,7 @@ steps:
 - template: SetupPythonPreReqs.yml
   parameters:
     install_python: ${{ parameters.install_tools }}
+    install_pip_modules: ${{ parameters.install_pip_modules }}
 
 # Set default
 - bash: echo "##vso[task.setvariable variable=pkg_count]${{ 1 }}"

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -72,6 +72,10 @@ parameters:
   displayName: Install Build Tools
   type: boolean
   default: true
+- name: install_pip_modules
+  displayName: Install PIP Modules
+  type: boolean
+  default: true
 - name: tool_chain_tag
   displayName: Tool Chain (e.g. VS2022)
   type: string
@@ -95,6 +99,7 @@ steps:
 - template: SetupPythonPreReqs.yml
   parameters:
     install_python: ${{ parameters.install_tools }}
+    install_pip_modules: ${{ parameters.install_pip_modules }}
 
 # Set Default Package Info
 - bash: |


### PR DESCRIPTION
SetupPythonPreReqs.yml already has a parameter with default set to true, but the user cannot change it. So, extending the install_pip_modules paramter, so that the user can override it