### PR TITLE
remove `-a` flag on stuart_build commands

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v9.1.9" %}
+{% set mu_devops = "v10.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202311" %}

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -18,10 +18,6 @@ parameters:
   displayName: Other Artifacts to Publish
   type: string
   default: ''
-- name: build_arch
-  displayName: Architectures (e.g. IA32, X64)
-  type: string
-  default: ''
 - name: build_base_tools
   displayName: Build BaseTools
   type: boolean
@@ -96,21 +92,21 @@ steps:
 - task: CmdLine@2
   displayName: Check if ${{ parameters.build_pkg }} Needs Testing
   inputs:
-    script: stuart_pr_eval -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target $(pr_compare_branch) --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
+    script: stuart_pr_eval -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} --pr-target $(pr_compare_branch) --output-count-format-string "##vso[task.setvariable variable=pkg_count]{pkgcount}"
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
  # Setup repo
 - task: CmdLine@2
   displayName: Setup
   inputs:
-    script: stuart_setup -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+    script: stuart_setup -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} ${{ parameters.build_flags}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
 # Stuart Update
 - task: CmdLine@2
   displayName: Update
   inputs:
-    script: stuart_update -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+    script: stuart_update -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} -t ${{ parameters.build_target}} ${{ parameters.build_flags}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
 # build basetools

--- a/Steps/BuildPlatform.yml
+++ b/Steps/BuildPlatform.yml
@@ -128,14 +128,14 @@ steps:
 - task: CmdLine@2
   displayName: Build
   inputs:
-    script: stuart_build -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}}
+    script: stuart_build -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} ${{ parameters.build_flags}}
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
 # Run
 - task: CmdLine@2
   displayName: Run to Shell
   inputs:
-    script: stuart_build -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} -a ${{ parameters.build_arch}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
+    script: stuart_build -c ${{ parameters.build_file }} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} TARGET=${{ parameters.build_target}} ${{ parameters.build_flags}} ${{ parameters.run_flags }} --FlashOnly
   condition: and(and(gt(variables.pkg_count, 0), succeeded()), eq(variables['Run'], true))
   timeoutInMinutes: ${{ parameters.run_timeout }}
 

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -157,9 +157,9 @@ steps:
 
 - ${{ if eq(parameters.do_non_ci_build, true) }}:
   - task: CmdLine@2
-    displayName: Build and Test ${{ parameters.build_pkgs }} ${{ parameters.build_archs}}
+    displayName: Build ${{ parameters.build_pkgs }}
     inputs:
-      script: stuart_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} -a ${{ parameters.build_archs}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
+      script: stuart_build -c ${{ parameters.build_file }} -p $(pkgs_to_build) -t ${{ parameters.build_targets}} TOOL_CHAIN_TAG=${{ parameters.tool_chain_tag}} ${{ parameters.extra_build_args}}
     condition: and(gt(variables.pkg_count, 0), succeeded())
 
 - ${{ if eq(parameters.do_ci_build, true) }}:


### PR DESCRIPTION
`-a` is not a first class parameter for stuart_build, so mu_devops should not expect that it exists. If a platform has added a necessary `-a` argument, then they can pass it to the command in mu_devops through the `build_flags` for BuildPlatform.yml or ` extra_build_args` for PrGate.yml
