### PR TITLE
Onboard Mu Rust PI to Mu DevOps

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -77,6 +77,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -125,6 +126,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_plus
@@ -174,6 +176,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -196,6 +199,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -221,6 +225,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -248,6 +253,7 @@ group:
       dest: LICENSE
     repos: |
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
 
 # GitHub Templates - Licensing - Project Mu and TianoCore License
   - files:
@@ -287,6 +293,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -315,6 +322,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -340,6 +348,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -436,6 +445,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -462,6 +472,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -487,6 +498,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -522,6 +534,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -547,6 +560,7 @@ group:
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_tiano_platforms
       microsoft/secureboot_objects
 
@@ -598,6 +612,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -629,6 +644,7 @@ group:
       microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano
       microsoft/mu_tiano_platforms
@@ -653,6 +669,7 @@ group:
       microsoft/mu_basecore
       microsoft/mu_plus
       microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
       microsoft/mu_tiano_platforms
 
 # Rust - Makefile (for UEFI builds)

--- a/Notebooks/MyPullRequests.github-issues
+++ b/Notebooks/MyPullRequests.github-issues
@@ -7,7 +7,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_rust_hid repo:microsoft/secureboot_objects"
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_rust_hid repo:microsoft/mu_rust_pi repo:microsoft/secureboot_objects"
   },
   {
     "kind": 1,

--- a/Notebooks/OpenIssues.github-issues
+++ b/Notebooks/OpenIssues.github-issues
@@ -12,7 +12,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_plus repo:microsoft/mu_tiano_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_tiano_platforms repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_feature_ipmi repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_python_library repo:microsoft/mu_pip_build repo:microsoft/mu_build repo:microsoft/mu_common_intel_adv_features  repo:microsoft/mu_rust_hid repo:microsoft/secureboot_objects"
+    "value": "// list of project mu repos\r\n$repos=repo:repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_plus repo:microsoft/mu_tiano_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_tiano_platforms repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_feature_ipmi repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_python_library repo:microsoft/mu_pip_build repo:microsoft/mu_build repo:microsoft/mu_common_intel_adv_features  repo:microsoft/mu_rust_hid repo:microsoft/mu_rust_pi repo:microsoft/secureboot_objects"
   },
   {
     "kind": 1,

--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -7,7 +7,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release  repo:microsoft/mu_rust_hid repo:microsoft/secureboot_objects"
+    "value": "// list of project mu repos\r\n$repos=repo:microsoft/mu repo:microsoft/mu_basecore repo:microsoft/mu_tiano_plus repo:microsoft/mu_plus repo:microsoft/mu_oem_sample repo:microsoft/mu_pip_python_library repo:microsoft/mu_silicon_arm_tiano repo:microsoft/mu_silicon_intel_tiano repo:microsoft/mu_tiano_platforms repo:microsoft/mu_pip_environment repo:microsoft/mu_pip_build repo:microsoft/mu_devops repo:microsoft/mu_feature_config repo:microsoft/mu_feature_debugger repo:microsoft/mu_feature_dfci repo:microsoft/mu_feature_ipmi repo:microsoft/mu_common_intel_min_platform repo:microsoft/mu_feature_mm_supv repo:microsoft/mu_common_intel_adv_features repo:microsoft/mu_feature_uefi_variable repo:microsoft/mu_crypto_release  repo:microsoft/mu_rust_hid repo:microsoft/mu_rust_pi repo:microsoft/secureboot_objects"
   },
   {
     "kind": 1,


### PR DESCRIPTION
Mu Rust Pi (https://github.com/microsoft/mu_rust_pi) hosts Rust code
for the Platform Initialization (PI) Specification.

This change sets up file syncing to the repo and adds the repo to the
GitHub notebooks.