### PR TITLE
.sync/codeql: Add retry on GitHub REST Access Failures

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -159,11 +159,21 @@ jobs:
         import os
         import requests
         import sys
+        import time
+
+        def get_response_with_retries(url, retries=5, wait_time=10):
+          for attempt in range(retries):
+            response = requests.get(url)
+            if response.status_code == 200:
+              return response
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed. Retrying in {wait_time} seconds...")
+            time.sleep(wait_time)
+          return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
 
-        response = requests.get(api_url)
+        response = get_response_with_retries(api_url)
         if response.status_code == 200:
           build_release_id = response.json()["id"]
         else:
@@ -172,7 +182,7 @@ jobs:
 
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
 
-        response = requests.get(api_url)
+        response = get_response_with_retries(api_url)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -164,11 +164,21 @@ jobs:
         import os
         import requests
         import sys
+        import time
+
+        def get_response_with_retries(url, retries=5, wait_time=10):
+          for attempt in range(retries):
+            response = requests.get(url)
+            if response.status_code == 200:
+              return response
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed. Retrying in {wait_time} seconds...")
+            time.sleep(wait_time)
+          return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
 
-        response = requests.get(api_url)
+        response = get_response_with_retries(api_url)
         if response.status_code == 200:
           build_release_id = response.json()["id"]
         else:
@@ -177,7 +187,7 @@ jobs:
 
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
 
-        response = requests.get(api_url)
+        response = get_response_with_retries(api_url)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:


### PR DESCRIPTION
Attempts sometimes fail on the first try and later succeed when
reaching out to the GitHub REST API. To prevent actions from having
to be rerun, try up to 5 times waiting 10 seconds between each try.