### PR TITLE
.sync/workflows/codeql: Bump release-downloader from v1.10 to v1.11

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -207,7 +207,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.11
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -212,7 +212,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.11
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'


### PR DESCRIPTION
Matches latest version synced to repos with dependabot.