### PR TITLE
Set ImageBase to 0 and Subsystem to EFI Boot Services in config.toml

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -697,3 +697,15 @@ group:
       microsoft/mu_basecore
       microsoft/mu_plus
       microsoft/mu_tiano_platforms
+
+# Rust - Config (for UEFI builds)
+  - files:
+    - source: .sync/rust_config/config.toml
+      dest: .cargo/config.toml
+    repos: |
+      microsoft/mu_basecore
+      microsoft/mu_plus
+      microsoft/mu_rust_helpers
+      microsoft/mu_rust_hid
+      microsoft/mu_rust_pi
+      microsoft/mu_tiano_platforms

--- a/.sync/rust_config/config.toml
+++ b/.sync/rust_config/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-uefi]
+rustflags = [
+    "-C", "link-arg=/base:0x0",
+    "-C", "link-arg=/subsystem:efi_boot_service_driver",
+]

--- a/.sync/rust_config/config.toml
+++ b/.sync/rust_config/config.toml
@@ -3,3 +3,15 @@ rustflags = [
     "-C", "link-arg=/base:0x0",
     "-C", "link-arg=/subsystem:efi_boot_service_driver",
 ]
+
+[target.i686-unknown-uefi]
+rustflags = [
+    "-C", "link-arg=/base:0x0",
+    "-C", "link-arg=/subsystem:efi_boot_service_driver",
+]
+
+[target.aarch64-unknown-uefi]
+rustflags = [
+    "-C", "link-arg=/base:0x0",
+    "-C", "link-arg=/subsystem:efi_boot_service_driver",
+]


### PR DESCRIPTION
Currently sets the ImageBase in the PE/COFF header to
`0` as expected for UEFI images.

The cargo config file will be synced to Rust enabled
repos to apply the linker flags regardless of whether
the Rust code is compiled directly or through the
firmware build system.