### PR TITLE
.sync: Simply PR description template

### DIFF
--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -21,7 +21,7 @@ submitted in the issues section.
 ## Security Vulnerabilities
 
 Please review the repos `Security Policy` but in general every Project Mu repo has `Private vulnerability reporting`
-enabled.  Please use the security tab to report a potential issue.  
+enabled.  Please use the security tab to report a potential issue.
 
 ### Identify Where to Report
 
@@ -62,6 +62,57 @@ configuration files. To aid maintainers in reviewing your code, we suggest adher
 4. Do introduce code in digestible amounts.
    * If the contribution logically be broken up into separate pull requests that independently build and function
      successfully, do use multiple pull requests.
+
+#### Pull Request Description Checkboxes
+
+Project Mu pull requests autopopulate a PR description from a template in most repositories. You should:
+
+1. **Replace** this text with an actual descrption:
+
+   ```txt
+   <_Include a description of the change and why this change was made._>
+   ```
+
+2. **Remove** this line of instructions so the PR description shows cleanly in release notes:
+
+   `"For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md)."`
+
+3. For each checkbox in the PR description, **place an "x"** in between `[` and `]` if true. Example: `[x]`.
+   _(you can also check items in the GitHub UI)_
+
+   * **[] Impacts functionality?**
+     * **Functionality** - Does the change ultimately impact how firmware functions?
+     * Examples: Add a new library, publish a new PPI, update an algorithm, ...
+   * **[] Impacts security?**
+     * **Security** - Does the change have a direct security impact on an application,
+       flow, or firmware?
+     * Examples: Crypto algorithm change, buffer overflow fix, parameter
+       validation improvement, ...
+   * **[] Breaking change?**
+     * **Breaking change** - Will anyone consuming this change experience a break
+       in build or boot behavior?
+     * Examples: Add a new library class, move a module to a different repo, call
+       a function in a new library class in a pre-existing module, ...
+   * [] **Includes tests?**
+     * **Tests** - Does the change include any explicit test code?
+     * Examples: Unit tests, integration tests, robot tests, ...
+   * [] **Includes documentation?**
+     * **Documentation** - Does the change contain explicit documentation additions
+       outside direct code modifications (and comments)?
+     * Examples: Update readme file, add feature readme file, link to documentation
+      on an a separate Web page, ...
+
+4. **Replace** this text as instructed:
+
+   ```txt
+   <_Describe the test(s) that were run to verify the changes._>
+   ```
+
+5. **Replace** this text as instructed:
+
+   ```txt
+   <_Describe how these changes should be integrated. Use N/A if nothing is required._>
+   ```
 
 #### Code Categories
 

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -1,41 +1,18 @@
-# Preface
-
-Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
-to submitting the pull request. In particular,
-[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).
-
 ## Description
 
-<_Please include a description of the change and why this change was made._>
+<_Include a description of the change and why this change was made._>
 
-For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
-_(you can also check items in the GitHub UI)_
+For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).
 
 - [ ] Impacts functionality?
-  - **Functionality** - Does the change ultimately impact how firmware functions?
-  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
 - [ ] Impacts security?
-  - **Security** - Does the change have a direct security impact on an application,
-    flow, or firmware?
-  - Examples: Crypto algorithm change, buffer overflow fix, parameter
-    validation improvement, ...
 - [ ] Breaking change?
-  - **Breaking change** - Will anyone consuming this change experience a break
-    in build or boot behavior?
-  - Examples: Add a new library class, move a module to a different repo, call
-    a function in a new library class in a pre-existing module, ...
 - [ ] Includes tests?
-  - **Tests** - Does the change include any explicit test code?
-  - Examples: Unit tests, integration tests, robot tests, ...
 - [ ] Includes documentation?
-  - **Documentation** - Does the change contain explicit documentation additions
-    outside direct code modifications (and comments)?
-  - Examples: Update readme file, add feature readme file, link to documentation
-    on an a separate Web page, ...
 
 ## How This Was Tested
 
-<_Please describe the test(s) that were run to verify the changes._>
+<_Describe the test(s) that were run to verify the changes._>
 
 ## Integration Instructions
 


### PR DESCRIPTION
- Remove a lot of boilerplate text
- Point to checkbox instructions instead of inplace instructions
  - Points to a single consistent location on the "mu" repo
- Update the `CONTRIBUTING.md` file in each repo to elaborate on how to fill out the PR template

---

There is a follow up item tracked in https://github.com/microsoft/mu_devops/issues/358 to make PR descriptions more consistently filled out so they appear as expected in release notes.