### PR TITLE
.sync/version.njk: Update latest Mu branch to 202405

### DIFF
--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -10,10 +10,10 @@
 # config file name varies depending on the branch being built.
 #
 #   1. A "latest release branch"
-#      - Example: `release/202311`
+#      - Example: `release/202405`
 #      - Config file: `release-draft-config-n.yml`
 #   2. A "previous release branch"
-#      - Example: `release/202302`
+#      - Example: `release/202311`
 #      - Config file: `release-draft-config-n-1.yml`
 #   3. A "main branch"
 #      - Example: `main`

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -580,7 +580,7 @@ group:
 
 # Leaf Workflow - Release Draft
 # Note: This group has two files synced that allow separate configuration for
-#       n (e.g. "release/202311") and n-1 (e.g. "release/202302") branches.
+#       n (e.g. "release/202405") and n-1 (e.g. "release/202311") branches.
   - files:
     - source: .sync/workflows/leaf/release-draft.yml
       dest: .github/workflows/release-draft.yml

--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -33,8 +33,8 @@
 {% set mu_devops = "v10.0.0" %}
 
 {# The latest Project Mu release branch value. #}
-{% set latest_mu_release_branch = "release/202311" %}
-{% set previous_mu_release_branch = "release/202302" %}
+{% set latest_mu_release_branch = "release/202405" %}
+{% set previous_mu_release_branch = "release/202311" %}
 
 {# The version of the ubuntu-22-build container to use. #}
 {% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:0e124c1" %}

--- a/Scripts/TagGenerator/Readme.md
+++ b/Scripts/TagGenerator/Readme.md
@@ -12,7 +12,7 @@ form such as PR links in tag notes.
 This script uses the `major.minor.patch` versioning scheme, but diverges from semantic
 versioning in some significant ways.
 
-- `major version` - Indicates the EDKII release tag that the repo is compiled against, e.g. `202311`.
+- `major version` - Indicates the EDKII release tag that the repo is compiled against, e.g. `202405`.
 - `minor version` - Indicates the breaking change number since the last major version change.
 - `patch version` - Indicates the number of non-breaking changes since the last minor version.
 


### PR DESCRIPTION
Also updates references to 202302 throughout the repo to prevent the examples from getting too stale over time.