### PR TITLE
Update the Rust toolchain to version 1.80.0

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -40,7 +40,7 @@
 {% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:0e124c1" %}
 
 {# The Rust toolchain version to use. #}
-{% set rust_toolchain = "1.76.0" %}
+{% set rust_toolchain = "1.80.0" %}
 
 {# Rust tool versions. #}
 {% set cargo_make = "0.37.9" %}


### PR DESCRIPTION
Update to a newer Rust toolchain in order to incorporate improvements with newer versions.
For example, an improvement on the size optimization of output rust binaries.