### PR TITLE
RustSetupSteps.yml: Update to latest cargo_tarpaulin 31.2 and Rust Toolchain

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -44,4 +44,4 @@
 
 {# Rust tool versions. #}
 {% set cargo_make = "0.37.9" %}
-{% set cargo_tarpaulin = "0.27.3" %}
+{% set cargo_tarpaulin = "0.31.2" %}

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -79,13 +79,13 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install --no-self-update 1.80.0
-  displayName: Install Rust 1.80.0 (Windows)
+    rustup install --no-self-update 1.76.0
+  displayName: Install Rust 1.76.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: |
-    rustup default 1.80.0
-  displayName: Set Rust 1.80.0 (Windows)
+    rustup default 1.76.0
+  displayName: Set Rust 1.76.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade
@@ -127,9 +127,9 @@ steps:
   displayName: Install cargo-make
 
 - script: |
-    cargo binstall -y cargo-tarpaulin --version 0.31.2
+    cargo binstall -y cargo-tarpaulin --version 0.27.3
   displayName: Install cargo-tarpaulin
 
-- script: rustup component add rustfmt rust-src --toolchain 1.80.0-$(rust_target_triple)
+- script: rustup component add rustfmt rust-src --toolchain 1.76.0-$(rust_target_triple)
   displayName: rustup add rust-src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/Steps/RustSetupSteps.yml
+++ b/Steps/RustSetupSteps.yml
@@ -79,13 +79,13 @@ steps:
 # those on both Linux and Windows agents for consistency in the pipeline runs.
 #
 - script: |
-    rustup install --no-self-update 1.76.0
-  displayName: Install Rust 1.76.0 (Windows)
+    rustup install --no-self-update 1.80.0
+  displayName: Install Rust 1.80.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: |
-    rustup default 1.76.0
-  displayName: Set Rust 1.76.0 (Windows)
+    rustup default 1.80.0
+  displayName: Set Rust 1.80.0 (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: pip install requests --upgrade
@@ -127,9 +127,9 @@ steps:
   displayName: Install cargo-make
 
 - script: |
-    cargo binstall -y cargo-tarpaulin --version 0.27.3
+    cargo binstall -y cargo-tarpaulin --version 0.31.2
   displayName: Install cargo-tarpaulin
 
-- script: rustup component add rustfmt rust-src --toolchain 1.76.0-$(rust_target_triple)
+- script: rustup component add rustfmt rust-src --toolchain 1.80.0-$(rust_target_triple)
   displayName: rustup add rust-src
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
Update to the latest version of cargo_tarpaulin, release 31.2. This change is required to allow tarpaulin to function with Rust toolchain 1.80. Running tarpaulin 27.3 with toolchain 1.80 results in the tool failing with a "Parse error".