### PR TITLE
Moved mu_oem_sample to release drafter for main instead of release/*"

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -577,6 +577,7 @@ group:
       microsoft/mu_rust_pi
       microsoft/mu_tiano_platforms
       microsoft/secureboot_objects
+      microsoft/mu_oem_sample
 
 # Leaf Workflow - Release Draft
 # Note: This group has two files synced that allow separate configuration for
@@ -599,7 +600,6 @@ group:
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
       microsoft/mu_crypto_release
-      microsoft/mu_oem_sample
       microsoft/mu_plus
       microsoft/mu_silicon_arm_tiano
       microsoft/mu_silicon_intel_tiano


### PR DESCRIPTION
mu_oem_sample is moving to a main, no longer being release/*.

This is due to oem_sample not needing to be tightly coupled to version releases of edk2.

Update the file sync to move over the correct of release drafter for a 'main' default branch. 