### PR TITLE
.sync/dependabot: Add Features/DEBUGGER to ignore list

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -80,6 +80,7 @@ updates:
       - dependency-name: "Common/MU_TIANO"
       - dependency-name: "Common/MU"
       - dependency-name: "Features/CONFIG"
+      - dependency-name: "Features/DEBUGGER"
       - dependency-name: "Features/DFCI"
       - dependency-name: "Features/IPMI"
       - dependency-name: "Features/MM_SUPV"


### PR DESCRIPTION
Let the submodule-release-updater GitHub action handle updates based on versioned GitHub releases.