### PR TITLE
Version.njk: Update to container version d1e4ff1

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202311" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:0e124c1" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:d1e4ff1" %}
 
 {# The Rust toolchain version to use. #}
 {% set rust_toolchain = "1.80.0" %}


### PR DESCRIPTION
Main reason to update is to use the latest Rust versions
in Version.njk.

```
{# The Rust toolchain version to use. #}
{% set rust_toolchain = "1.80.0" %}

{# Rust tool versions. #}
{% set cargo_make = "0.37.9" %}
{% set cargo_tarpaulin = "0.31.2" %}
```

A complete list of changes compared to the previous container
version (`0e124c1`) is in:

https://github.com/microsoft/mu_devops/compare/0e124c1...d1e4ff1