### PR TITLE
Version.njk: Update to container version 4bebc96

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202311" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:d1e4ff1" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:4bebc96" %}
 
 {# The Python version to use. #}
 {% set python_version = "3.12" %}


### PR DESCRIPTION
Main reason to update is to pick up the latest Ubuntu container build that uses Python 3.12.

A complete list of changes compared to the previous container version (`d1e4ff1`) is in:

https://github.com/microsoft/mu_devops/compare/d1e4ff1...4bebc96