### PR TITLE
.sync/rust_config/rustfmt.toml: Add struct and enum alignment

### DIFF
--- a/.sync/rust_config/rustfmt.toml
+++ b/.sync/rust_config/rustfmt.toml
@@ -5,17 +5,19 @@
 
 # Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
 
-edition = "2021"              # This would normally be picked up from Cargo.toml if not specified here
-force_explicit_abi = true     # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
-hard_tabs = false             # Always uses spaces for indentation and alignment
-max_width = 120               # The maximum width of each line
-merge_derives = false         # Do not merge derives into a single line (leave to author discretion).
-imports_granularity = "Crate" # Merge imports from a single crate into separate statements.
-newline_style = "Windows"     # Always use Windows line endings '\r\n'
-reorder_impl_items = false    # Do not force where type and const before macros and methods in impl blocks.
-reorder_imports = true        # Do reorder import and extern crate statements alphabetically for readability.
-reorder_modules = true        # Do reorder mod declarations alphabetically for readability.
-tab_spaces = 4                # Use 4 spaces for indentation (Rust default).
-unstable_features = false     # Do not use unstable rustfmt features.
-use_small_heuristics = "Max"  # Set all granular width settings to the same as max_width (do not use heuristics)
-wrap_comments = false         # Leave comment formatting to author's discretion
+edition = "2021"                 # This would normally be picked up from Cargo.toml if not specified here
+enum_discrim_align_threshold = 8 # Vertically align enum discriminants
+force_explicit_abi = true        # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
+hard_tabs = false                # Always uses spaces for indentation and alignment
+max_width = 120                  # The maximum width of each line
+merge_derives = false            # Do not merge derives into a single line (leave to author discretion).
+imports_granularity = "Crate"    # Merge imports from a single crate into separate statements.
+newline_style = "Windows"        # Always use Windows line endings '\r\n'
+reorder_impl_items = false       # Do not force where type and const before macros and methods in impl blocks.
+reorder_imports = true           # Do reorder import and extern crate statements alphabetically for readability.
+reorder_modules = true           # Do reorder mod declarations alphabetically for readability.
+struct_field_align_threshold = 8 # Vertically align struct fields
+tab_spaces = 4                   # Use 4 spaces for indentation (Rust default).
+unstable_features = false        # Do not use unstable rustfmt features.
+use_small_heuristics = "Max"     # Set all granular width settings to the same as max_width (do not use heuristics)
+wrap_comments = false            # Leave comment formatting to author's discretion


### PR DESCRIPTION
Add arguments to rustfmt for vertically aligning struct and enum members. Usage requires `+nightly`.

Value of 8 matches 'align_var_struct_span' from uncrustify.cfg.