### PR TITLE
.sync/rust-toolchain.toml: Use [tools] section

### DIFF
--- a/.sync/rust_config/rust-toolchain.toml
+++ b/.sync/rust_config/rust-toolchain.toml
@@ -3,6 +3,6 @@
 [toolchain]
 channel = "{{ sync_version.rust_toolchain }}"
 
-[tool]
+[tools]
 cargo-make = "{{ sync_version.cargo_make }}"
 cargo-tarpaulin = "{{ sync_version.cargo_tarpaulin }}"


### PR DESCRIPTION
Current automation and scripts expect the section with tools to be called "[tools]".