### PR TITLE
.sync/Version.njk: Update cargo-make and cargo-tarpaulin to latest

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -46,5 +46,5 @@
 {% set rust_toolchain = "1.80.0" %}
 
 {# Rust tool versions. #}
-{% set cargo_make = "0.37.9" %}
-{% set cargo_tarpaulin = "0.31.2" %}
+{% set cargo_make = "0.37.24" %}
+{% set cargo_tarpaulin = "0.31.5" %}


### PR DESCRIPTION
Since `cargo-binstall` is being used to install Rust binaries, update to the latest version of `cargo-make` and `cargo-tarpaulin`.

Note: `RustSetupSteps.yml` in this repo gets updated from this version during the file sync.