### PR TITLE
Containers/Ubuntu-22: Remove pythonx.x-distutils

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -70,7 +70,6 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install --yes --no-install-recommends \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
-        {% endraw %}python{{ sync_version.python_version }}{% raw %}-distutils \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \

--- a/Containers/Ubuntu-22/Dockerfile
+++ b/Containers/Ubuntu-22/Dockerfile
@@ -67,7 +67,6 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install --yes --no-install-recommends \
         python3.12 \
-        python3.12-distutils \
         python3.12-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \


### PR DESCRIPTION
The `pythonx.x-distutils` package provided the standard `distutils` module for our Ubuntu container Python environment.

In the deadsnakes PPA python3.12.7-1+jammy1 to python3.12.8-1+jammy1 update on 12/04/2024, the following diff was made:

https://launchpadlibrarian.net/761821028/python3.12_3.12.7-1+jammy1_3.12.8-1+jammy1.diff.gz

In that, `python3.12-distutils` is no longer a built package per [PEP-0632](https://peps.python.org/pep-0632/). Therefore, it is removed from the container using Python 3.12 and some subsequent Python code updates may need to made for compatibility.

This change is specifically focused on fixing the Ubuntu 22.04 (jammy) container build.

---

Marked as a breaking change since `distutils` will no longer be installed in the container.