### PR TITLE
Version.njk: Update Ubuntu build container version and use Mu Devops 12.4.2

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,14 +30,14 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v12.4.0" %}
+{% set mu_devops = "v12.4.2" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202405" %}
 {% set previous_mu_release_branch = "release/202311" %}
 
 {# The version of the ubuntu-22-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:4bebc96" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-22-build:af4ec63" %}
 
 {# The Python version to use. #}
 {% set python_version = "3.12" %}


### PR DESCRIPTION
- Updates the container to latest `af4ec63`
  - This container image does not have `python3.12-distutils`
- Updates the Mu DevOps version synced from "v12.4.0" to "v12.4.2".

---

Marked as breaking change due to the container update that contains a potentially breaking change.