### PR TITLE
Add Ubuntu 24.04 (Noble Numbat) container build

### DIFF
--- a/.github/workflows/Build-Containers.yml
+++ b/.github/workflows/Build-Containers.yml
@@ -35,6 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - image_name: "Ubuntu-24"
+            sub_images: "dev test build"
           - image_name: "Ubuntu-22"
             sub_images: "dev test build"
     env:

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -111,6 +111,9 @@ group:
 
 # Containers - Dockerfiles
   - files:
+    - source: .sync/containers/Ubuntu-24/Dockerfile
+      dest: Containers/Ubuntu-24/Dockerfile
+      template: true
     - source: .sync/containers/Ubuntu-22/Dockerfile
       dest: Containers/Ubuntu-22/Dockerfile
       template: true

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -1,0 +1,231 @@
+#
+#  Dockerfile for building/testing Project MU with GCC.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+#  Copyright (c) Microsoft Corporation
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+{% import '../../Version.njk' as sync_version -%}
+
+{% raw %}
+# NOTE: Because this pipeline YAML file is a Nunjucks template, the pipeline syntax of `{{}}` will conflict with
+#       Nunjucks style. Surround pipeline YAML code that uses `{{}}` within `raw` and `endraw` tags
+#       to allow it to pass through Nunjucks processing.
+
+#
+# The build container layer is intended for pipeline use and is the minimal set
+# of tools required for building Project MU.
+#
+FROM ubuntu:24.04 AS build
+
+# Versions
+ARG GCC_MAJOR_VERSION=12
+ARG NASM_VERSION=2.16.01
+ARG CSPELL_VERSION=5.20.0
+ARG MARKDOWNLINT_VERSION=0.32.2
+
+# Visit this NuGet package version page to see the latest version available
+# https://dev.azure.com/projectmu/acpica/_artifacts/feed/mu_iasl/NuGet/edk2-acpica-iasl/versions
+ARG IASL_VERSION=20210105.0.6
+
+# Set environment variable to avoid interaction.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Work-around for azure pipelines adding the vsts_azpcontainer user, but not adding
+# the .local/bin directory to the path which will be used by pip.
+ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        bison \
+        ca-certificates \
+        curl \
+        flex \
+        git \
+        gnupg \
+        gnupg2 \
+        lcov \
+        jq \
+        m4 \
+        make \
+        mono-complete \
+        nasm \
+        npm \
+        software-properties-common \
+        sudo \
+        unzip \
+        uuid-dev \
+        wget \
+        && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        {% endraw %}python{{ sync_version.python_version }}{% raw %} \
+        {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
+        g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
+        gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
+        gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \
+        gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabi \
+        gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf \
+        && \
+        {% endraw %}python{{ sync_version.python_version }}{% raw %} -m venv /opt/venv && \
+        /opt/venv/bin/pip install --upgrade pip setuptools && \
+        apt-get upgrade -y && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/venv/bin:$PATH"
+ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnueabi-
+ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+
+RUN pip install pip lcov_cobertura --upgrade
+
+# RUN npm install -g npm
+RUN npm install -g \
+        cspell@${CSPELL_VERSION} \
+        markdownlint-cli@${MARKDOWNLINT_VERSION}
+
+RUN wget -O - https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz | \
+    tar xz && cd nasm-${NASM_VERSION} && \
+    ./autogen.sh && ./configure && make -j $(nproc) && make install && \
+    cd .. && rm -rf nasm-${NASM_VERSION}
+
+RUN mkdir -p iasl_temp && cd iasl_temp && \
+    wget -O iasl_${IASL_VERSION}.nupkg "https://pkgs.dev.azure.com/projectmu/acpica/_apis/packaging/feeds/mu_iasl/nuget/packages/edk2-acpica-iasl/versions/${IASL_VERSION}/content?api-version=6.0-preview.1" && \
+    unzip iasl_${IASL_VERSION}.nupkg -d /iasl_pkg_contents && \
+    find /iasl_pkg_contents -type f -name "iasl" -exec cp {} /usr/bin \; && chmod +x /usr/bin/iasl && \
+    cd .. && rm -rf iasl_temp
+
+RUN wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" && \
+    dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && \
+    apt-get update && apt-get install -y powershell && apt-get clean
+
+#
+# Rust support
+#
+
+ENV CARGO_HOME="$HOME/.cargo"
+ENV RUSTUP_HOME="$HOME/.rustup"
+ENV PATH="$CARGO_HOME/bin:$PATH"
+
+# Install Rust/Cargo and extras (rust-src, rust fmt, cargo-make, cargo-tarpaulin)
+RUN VERSION_URL="https://raw.githubusercontent.com/microsoft/mu_devops/main/.sync/Version.njk" && \
+    RUST_VERSION=$(curl -s ${VERSION_URL} | grep -oP '(?<=rust_toolchain = ").*(?=")') && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
+    rustup component add rustfmt rust-src --toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu
+
+RUN mkdir cargo_downloads && \
+    cd cargo_downloads && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/sagiegurari/cargo-make/releases/download/$TAG_NAME/cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu.zip" && \
+    curl -L -o cargo-make.zip "$DOWNLOAD_URL" && \
+    unzip cargo-make.zip && \
+    mv cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu/cargo-make $CARGO_HOME/bin/ && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/xd009642/tarpaulin/releases/download/$TAG_NAME/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz" && \
+    curl -L -o cargo-tarpaulin.tar.gz "$DOWNLOAD_URL" && \
+    tar -xzvf cargo-tarpaulin.tar.gz && \
+    mv cargo-tarpaulin $CARGO_HOME/bin/ && \
+    cd .. && \
+    rm -r cargo_downloads
+
+#
+# Alternatives
+#
+{% endraw %}
+
+RUN update-alternatives \
+      --install /usr/bin/python python /usr/bin/python{{ sync_version.python_version }} 1 && \
+    update-alternatives \
+      --install /usr/bin/python3 python3 /usr/bin/python{{ sync_version.python_version }} 1 && \
+    update-alternatives \
+      --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives --remove-all cpp && \
+    update-alternatives \
+      --install /usr/bin/cpp cpp /usr/bin/cpp-${GCC_MAJOR_VERSION} 100 && \
+    update-alternatives \
+      --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/aarch64-linux-gnu-cpp aarch64-linux-gnu-cpp /usr/bin/aarch64-linux-gnu-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-ar aarch64-linux-gnu-gcc-ar /usr/bin/aarch64-linux-gnu-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-nm aarch64-linux-gnu-gcc-nm /usr/bin/aarch64-linux-gnu-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-ranlib aarch64-linux-gnu-gcc-ranlib /usr/bin/aarch64-linux-gnu-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives \
+      --install /usr/bin/arm-linux-gnueabi-gcc arm-linux-gnueabi-gcc /usr/bin/arm-linux-gnueabi-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/arm-linux-gnueabi-cpp arm-linux-gnueabi-cpp /usr/bin/arm-linux-gnueabi-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-g++ arm-linux-gnueabi-g++ /usr/bin/arm-linux-gnueabi-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-ar arm-linux-gnueabi-gcc-ar /usr/bin/arm-linux-gnueabi-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-nm arm-linux-gnueabi-gcc-nm /usr/bin/arm-linux-gnueabi-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-ranlib arm-linux-gnueabi-gcc-ranlib /usr/bin/arm-linux-gnueabi-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcov arm-linux-gnueabi-gcov /usr/bin/arm-linux-gnueabi-gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives \
+      --install /usr/bin/riscv64-linux-gnu-gcc riscv64-linux-gnu-gcc /usr/bin/riscv64-linux-gnu-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/riscv64-linux-gnu-cpp riscv64-linux-gnu-cpp /usr/bin/riscv64-linux-gnu-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-g++ riscv64-linux-gnu-g++ /usr/bin/riscv64-linux-gnu-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-ar riscv64-linux-gnu-gcc-ar /usr/bin/riscv64-linux-gnu-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-nm riscv64-linux-gnu-gcc-nm /usr/bin/riscv64-linux-gnu-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-ranlib riscv64-linux-gnu-gcc-ranlib /usr/bin/riscv64-linux-gnu-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcov riscv64-linux-gnu-gcov /usr/bin/riscv64-linux-gnu-gcov-${GCC_MAJOR_VERSION}
+
+{% raw %}
+#
+# The test container layer is intended for pipeline use and virtual platform tools
+# on top of the base build image.
+#
+FROM build AS test
+
+ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
+ARG QEMU_BRANCH="v9.0.0"
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+        autoconf \
+        automake \
+        autotools-dev \
+        bc \
+        build-essential \
+        dosfstools \
+        gcc \
+        libglib2.0-dev \
+        libgtk-3-dev \
+        libpixman-1-dev \
+        libsdl2-dev \
+        mtools \
+        ninja-build \
+        tar \
+        && \
+    git clone "${QEMU_URL}" --branch "${QEMU_BRANCH}" --depth 1 qemu && \
+    cd qemu && \
+    ./configure --target-list=x86_64-softmmu,aarch64-softmmu --enable-gtk && \
+    make install -j $(nproc) && \
+    cd .. && \
+    rm -rf qemu && \
+    apt remove --yes ninja-build && \
+    apt-get clean
+
+#
+# The dev container layer is intended for local use and has more robust tooling
+# and environment configurations for developers.
+#
+FROM test AS dev
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        nano \
+        less \
+        && \
+    apt-get clean
+{% endraw %}

--- a/Containers/Readme.md
+++ b/Containers/Readme.md
@@ -1,17 +1,30 @@
-# MU Devops Containers
+# Mu Devops Containers
 
-Project MU uses containers to build on Linux. These containers come with all of
+Project Mu uses containers to build on Linux. These containers come with all of
 the tools expected for CI and virtual platform pipelines and local development.
 Containers can be pulled. For more details see the [mu_devops packages page](https://github.com/orgs/microsoft/packages?repo_name=mu_devops).
 
-## Ubuntu-22 _(Recommended)_
+## Ubuntu-24 _(Recommended)_
 
-The MU Ubuntu container provides the following layers. Ubuntu-22 is the recommended
+The Mu Ubuntu container provides the following layers. Ubuntu-24 is the recommended
 container image because it best aligns with existing development flows and provides
-tools needed to cross compile both kernel and user mode components needed in MU.
+tools needed to cross compile both kernel and user mode components needed in Mu.
+
+## Ubuntu-22
+
+Ubuntu-22 is the previous Ubuntu container image used in Mu CI from May 2023 until
+February 2025. It is still available for use, but is not recommended for new projects
+and other CI dependencies and worfklows may not be supported with it.
+
+It will be deprecated soon. Users should migrate to Ubuntu-24 as soon as possible.
+
+---
 
 | Name  | Description                          | Package |
 |-------|--------------------------------------|---------|
-| Build | Used for CI pipeline builds.         | [ubuntu-22-build](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-build) |
-| Test  | Used for virtual platform pipelines. | [ubuntu-22-test](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-test) |
-| Dev   | Used local development.              | [ubuntu-22-dev](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-dev) |
+| Build | Used for CI pipeline builds.         | [ubuntu-24-build](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-24-build) |
+| Test  | Used for virtual platform pipelines. | [ubuntu-24-test](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-24-test) |
+| Dev   | Used local development.              | [ubuntu-24-dev](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-24-dev) |
+| Build | Ubuntu 22 (older) pipeline build.    | [ubuntu-22-build](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-build) |
+| Test  | Ubuntu 22 (older) virt plat image.   | [ubuntu-22-test](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-test) |
+| Dev   | Ubuntu 22 (older) local dev image    | [ubuntu-22-dev](https://github.com/microsoft/mu_devops/pkgs/container/mu_devops%2Fubuntu-22-dev) |

--- a/Containers/Ubuntu-24/Dockerfile
+++ b/Containers/Ubuntu-24/Dockerfile
@@ -1,0 +1,227 @@
+#
+#  Dockerfile for building/testing Project MU with GCC.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+#  Copyright (c) Microsoft Corporation
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+# NOTE: Because this pipeline YAML file is a Nunjucks template, the pipeline syntax of `{{}}` will conflict with
+#       Nunjucks style. Surround pipeline YAML code that uses `{{}}` within `raw` and `endraw` tags
+#       to allow it to pass through Nunjucks processing.
+
+#
+# The build container layer is intended for pipeline use and is the minimal set
+# of tools required for building Project MU.
+#
+FROM ubuntu:24.04 AS build
+
+# Versions
+ARG GCC_MAJOR_VERSION=12
+ARG NASM_VERSION=2.16.01
+ARG CSPELL_VERSION=5.20.0
+ARG MARKDOWNLINT_VERSION=0.32.2
+
+# Visit this NuGet package version page to see the latest version available
+# https://dev.azure.com/projectmu/acpica/_artifacts/feed/mu_iasl/NuGet/edk2-acpica-iasl/versions
+ARG IASL_VERSION=20210105.0.6
+
+# Set environment variable to avoid interaction.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Work-around for azure pipelines adding the vsts_azpcontainer user, but not adding
+# the .local/bin directory to the path which will be used by pip.
+ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        bison \
+        ca-certificates \
+        curl \
+        flex \
+        git \
+        gnupg \
+        gnupg2 \
+        lcov \
+        jq \
+        m4 \
+        make \
+        mono-complete \
+        nasm \
+        npm \
+        software-properties-common \
+        sudo \
+        unzip \
+        uuid-dev \
+        wget \
+        && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        python3.12 \
+        python3.12-venv \
+        g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
+        gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
+        gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \
+        gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabi \
+        gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf \
+        && \
+        python3.12 -m venv /opt/venv && \
+        /opt/venv/bin/pip install --upgrade pip setuptools && \
+        apt-get upgrade -y && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/venv/bin:$PATH"
+ENV GCC5_AARCH64_PREFIX /usr/bin/aarch64-linux-gnu-
+ENV GCC5_ARM_PREFIX     /usr/bin/arm-linux-gnueabi-
+ENV GCC5_RISCV64_PREFIX /usr/bin/riscv64-linux-gnu-
+
+RUN pip install pip lcov_cobertura --upgrade
+
+# RUN npm install -g npm
+RUN npm install -g \
+        cspell@${CSPELL_VERSION} \
+        markdownlint-cli@${MARKDOWNLINT_VERSION}
+
+RUN wget -O - https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz | \
+    tar xz && cd nasm-${NASM_VERSION} && \
+    ./autogen.sh && ./configure && make -j $(nproc) && make install && \
+    cd .. && rm -rf nasm-${NASM_VERSION}
+
+RUN mkdir -p iasl_temp && cd iasl_temp && \
+    wget -O iasl_${IASL_VERSION}.nupkg "https://pkgs.dev.azure.com/projectmu/acpica/_apis/packaging/feeds/mu_iasl/nuget/packages/edk2-acpica-iasl/versions/${IASL_VERSION}/content?api-version=6.0-preview.1" && \
+    unzip iasl_${IASL_VERSION}.nupkg -d /iasl_pkg_contents && \
+    find /iasl_pkg_contents -type f -name "iasl" -exec cp {} /usr/bin \; && chmod +x /usr/bin/iasl && \
+    cd .. && rm -rf iasl_temp
+
+RUN wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" && \
+    dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb && \
+    apt-get update && apt-get install -y powershell && apt-get clean
+
+#
+# Rust support
+#
+
+ENV CARGO_HOME="$HOME/.cargo"
+ENV RUSTUP_HOME="$HOME/.rustup"
+ENV PATH="$CARGO_HOME/bin:$PATH"
+
+# Install Rust/Cargo and extras (rust-src, rust fmt, cargo-make, cargo-tarpaulin)
+RUN VERSION_URL="https://raw.githubusercontent.com/microsoft/mu_devops/main/.sync/Version.njk" && \
+    RUST_VERSION=$(curl -s ${VERSION_URL} | grep -oP '(?<=rust_toolchain = ").*(?=")') && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
+    rustup component add rustfmt rust-src --toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu
+
+RUN mkdir cargo_downloads && \
+    cd cargo_downloads && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/sagiegurari/cargo-make/releases/download/$TAG_NAME/cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu.zip" && \
+    curl -L -o cargo-make.zip "$DOWNLOAD_URL" && \
+    unzip cargo-make.zip && \
+    mv cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu/cargo-make $CARGO_HOME/bin/ && \
+    TAG_NAME=$(curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL="https://github.com/xd009642/tarpaulin/releases/download/$TAG_NAME/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz" && \
+    curl -L -o cargo-tarpaulin.tar.gz "$DOWNLOAD_URL" && \
+    tar -xzvf cargo-tarpaulin.tar.gz && \
+    mv cargo-tarpaulin $CARGO_HOME/bin/ && \
+    cd .. && \
+    rm -r cargo_downloads
+
+#
+# Alternatives
+#
+
+
+RUN update-alternatives \
+      --install /usr/bin/python python /usr/bin/python3.12 1 && \
+    update-alternatives \
+      --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    update-alternatives \
+      --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives --remove-all cpp && \
+    update-alternatives \
+      --install /usr/bin/cpp cpp /usr/bin/cpp-${GCC_MAJOR_VERSION} 100 && \
+    update-alternatives \
+      --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/aarch64-linux-gnu-cpp aarch64-linux-gnu-cpp /usr/bin/aarch64-linux-gnu-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-ar aarch64-linux-gnu-gcc-ar /usr/bin/aarch64-linux-gnu-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-nm aarch64-linux-gnu-gcc-nm /usr/bin/aarch64-linux-gnu-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcc-ranlib aarch64-linux-gnu-gcc-ranlib /usr/bin/aarch64-linux-gnu-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/aarch64-linux-gnu-gcov aarch64-linux-gnu-gcov /usr/bin/aarch64-linux-gnu-gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives \
+      --install /usr/bin/arm-linux-gnueabi-gcc arm-linux-gnueabi-gcc /usr/bin/arm-linux-gnueabi-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/arm-linux-gnueabi-cpp arm-linux-gnueabi-cpp /usr/bin/arm-linux-gnueabi-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-g++ arm-linux-gnueabi-g++ /usr/bin/arm-linux-gnueabi-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-ar arm-linux-gnueabi-gcc-ar /usr/bin/arm-linux-gnueabi-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-nm arm-linux-gnueabi-gcc-nm /usr/bin/arm-linux-gnueabi-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcc-ranlib arm-linux-gnueabi-gcc-ranlib /usr/bin/arm-linux-gnueabi-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/arm-linux-gnueabi-gcov arm-linux-gnueabi-gcov /usr/bin/arm-linux-gnueabi-gcov-${GCC_MAJOR_VERSION} && \
+    update-alternatives \
+      --install /usr/bin/riscv64-linux-gnu-gcc riscv64-linux-gnu-gcc /usr/bin/riscv64-linux-gnu-gcc-${GCC_MAJOR_VERSION} 100 \
+      --slave /usr/bin/riscv64-linux-gnu-cpp riscv64-linux-gnu-cpp /usr/bin/riscv64-linux-gnu-cpp-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-g++ riscv64-linux-gnu-g++ /usr/bin/riscv64-linux-gnu-g++-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-ar riscv64-linux-gnu-gcc-ar /usr/bin/riscv64-linux-gnu-gcc-ar-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-nm riscv64-linux-gnu-gcc-nm /usr/bin/riscv64-linux-gnu-gcc-nm-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcc-ranlib riscv64-linux-gnu-gcc-ranlib /usr/bin/riscv64-linux-gnu-gcc-ranlib-${GCC_MAJOR_VERSION} \
+      --slave /usr/bin/riscv64-linux-gnu-gcov riscv64-linux-gnu-gcov /usr/bin/riscv64-linux-gnu-gcov-${GCC_MAJOR_VERSION}
+
+#
+# The test container layer is intended for pipeline use and virtual platform tools
+# on top of the base build image.
+#
+FROM build AS test
+
+ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
+ARG QEMU_BRANCH="v9.0.0"
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+        autoconf \
+        automake \
+        autotools-dev \
+        bc \
+        build-essential \
+        dosfstools \
+        gcc \
+        libglib2.0-dev \
+        libgtk-3-dev \
+        libpixman-1-dev \
+        libsdl2-dev \
+        mtools \
+        ninja-build \
+        tar \
+        && \
+    git clone "${QEMU_URL}" --branch "${QEMU_BRANCH}" --depth 1 qemu && \
+    cd qemu && \
+    ./configure --target-list=x86_64-softmmu,aarch64-softmmu --enable-gtk && \
+    make install -j $(nproc) && \
+    cd .. && \
+    rm -rf qemu && \
+    apt remove --yes ninja-build && \
+    apt-get clean
+
+#
+# The dev container layer is intended for local use and has more robust tooling
+# and environment configurations for developers.
+#
+FROM test AS dev
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        nano \
+        less \
+        && \
+    apt-get clean
+


### PR DESCRIPTION
Closes #403 

Adds a new dockerfile to build a Ubuntu 24.04 image.

- https://releases.ubuntu.com/noble/

As we continue to update other Linux dependencies such as our Python installation and various packages, we can maintain better compatibility with pre-compiled binaries and get newer, safer updates by moving to the latest Ubuntu stable release.

In particular, glibc 2.39 is now included by default which allows us to move ahead to newer binaries being pulled into the build like `cargo-make` v0.37.24.

---

Ubuntu 22.04 image:

  ```
  /.cargo/bin/cargo-make: /lib/x86_64-linux-gnu/libc.so.6: version
  `GLIBC_2.39' not found (required by /.cargo/bin/cargo-make)
  ```

Ubuntu 24.04 image:

  ```
  root@4d1e94a3013a:/src/mu_tiano_platforms# lsb_release -a
  No LSB modules are available.
  Distributor ID: Ubuntu
  Description:    Ubuntu 24.04.1 LTS
  Release:        24.04
  Codename:       noble
  ```

  ```
  root@4d1e94a3013a:/mu_plus# ldd --version
  ldd (Ubuntu GLIBC 2.39-0ubuntu8.3) 2.39
  Copyright (C) 2024 Free Software Foundation, Inc.
  This is free software; see the source for copying conditions.  There is NO
  warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  Written by Roland McGrath and Ulrich Drepper
  ```

  ```
  root@4d1e94a3013a:/mu_plus# cargo make test
  [cargo-make] INFO - cargo make 0.37.24
  [cargo-make] INFO -
  [cargo-make] INFO - Build File: Makefile.toml
  [cargo-make] INFO - Task: test
  [cargo-make] INFO - Profile: development
  [cargo-make] INFO - Running Task: individual-package-targets
  [cargo-make] INFO - Execute Command: "cargo" "test"
  ```

  Powershell in the new image:

  ```
   root@4d1e94a3013a:/mu_plus# pwsh
   PowerShell 7.5.0
   ```