### PR TITLE
Containers/Ubuntu-24: Allow CI user access to venv

### DIFF
--- a/Containers/Ubuntu-24/Dockerfile
+++ b/Containers/Ubuntu-24/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && \
         gcc-${GCC_MAJOR_VERSION}-arm-linux-gnueabihf \
         && \
         python3.12 -m venv /opt/venv && \
+        chmod -R g+w,o+w /opt/venv && \
         /opt/venv/bin/pip install --upgrade pip setuptools && \
         apt-get upgrade -y && \
         apt-get clean && \


### PR DESCRIPTION
Many of the existing CI workflows expect a pip environment to use. A new user and group are created for the docker user when the container image is initialized in pipelines. This allows that user to use the /opt/venv environment to support existing workflows.