### PR TITLE
.sync/Version.njk: Update Ubuntu 24.04 container to d412ccd

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202311" %}
 
 {# The version of the ubuntu-24-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:352ed44" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:d412ccd" %}
 
 {# The Python version to use. #}
 {% set python_version = "3.12" %}


### PR DESCRIPTION
Includes the change to allow the CI user account to use pip.