### PR TITLE
Add Cargo Tool upload pipelines

### DIFF
--- a/.azurepipelines/CargoMakeArtifact.yml
+++ b/.azurepipelines/CargoMakeArtifact.yml
@@ -13,7 +13,7 @@ parameters:
   - name: python_version
     displayName: 'Python Version'
     type: string
-    default: '3.11'
+    default: '3.12'
 
 extends:
   template: templates/CargoToolRepublish.yml

--- a/.azurepipelines/CargoMakeArtifact.yml
+++ b/.azurepipelines/CargoMakeArtifact.yml
@@ -1,0 +1,26 @@
+## @file
+# Azure Pipeline to build and publish Cargo Make in a format supported by edk2-pytool-extension's external dependency.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+trigger: none
+
+parameters:
+  - name: tag
+    displayName: 'Cargo Make Version Tag'
+    type: string
+  - name: python_version
+    displayName: 'Python Version'
+    type: string
+    default: '3.11'
+
+extends:
+  template: templates/CargoToolRepublish.yml
+  parameters:
+    tool_name: 'cargo-make'
+    tag: ${{ parameters.tag }}
+    repo_url: 'https://github.com/sagiegurari/cargo-make.git'
+    python_version: ${{ parameters.python_version }}
+    upload_linux: true
+    upload_windows: true

--- a/.azurepipelines/CargoTarpaulinArtifact.yml
+++ b/.azurepipelines/CargoTarpaulinArtifact.yml
@@ -14,7 +14,7 @@ parameters:
   - name: python_version
     displayName: 'Python Version'
     type: string
-    default: '3.11'
+    default: '3.12'
 
 extends:
   template: templates/CargoToolRepublish.yml

--- a/.azurepipelines/CargoTarpaulinArtifact.yml
+++ b/.azurepipelines/CargoTarpaulinArtifact.yml
@@ -1,0 +1,28 @@
+## @file
+# Azure Pipeline to build and publish Cargo Tarpaulin in a format supported by edk2-pytool-extension's external
+# dependency.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+trigger: none
+
+parameters:
+  - name: tag
+    displayName: 'Cargo Tarpaulin Version Tag'
+    type: string
+  - name: python_version
+    displayName: 'Python Version'
+    type: string
+    default: '3.11'
+
+extends:
+  template: templates/CargoToolRepublish.yml
+  parameters:
+    tool_name: 'cargo-tarpaulin'
+    extra_build_args: '--all-features'
+    tag: ${{ parameters.tag }}
+    repo_url: 'https://github.com/xd009642/tarpaulin.git'
+    python_version: ${{ parameters.python_version }}
+    upload_linux: true
+    upload_windows: true

--- a/.azurepipelines/nuget/cargo-make.yaml
+++ b/.azurepipelines/nuget/cargo-make.yaml
@@ -1,0 +1,8 @@
+author_string: Microsoft Corporation
+copyright_string: Copyright (c) Microsoft Corporation
+description_string: Re-publish of cargo-make binaries
+license_url: http://www.microsoft.com/
+name: cargo_make
+project_url: https://microsoft.github.com/mu
+server_url: https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json
+tags_string: ''

--- a/.azurepipelines/nuget/cargo-tarpaulin.yaml
+++ b/.azurepipelines/nuget/cargo-tarpaulin.yaml
@@ -1,0 +1,8 @@
+author_string: Microsoft Corporation
+copyright_string: Copyright (c) Microsoft Corporation
+description_string: Re-publish of cargo-tarpaulin binaries
+license_url: http://www.microsoft.com/
+name: cargo_tarpaulin
+project_url: https://microsoft.github.com/mu
+server_url: https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json
+tags_string: ''

--- a/.azurepipelines/nuget/license.txt
+++ b/.azurepipelines/nuget/license.txt
@@ -1,0 +1,1 @@
+Copyright (c) Microsoft Corporation. All rights reserved.

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -38,7 +38,7 @@ variables:
   - name: windows_image
     value: 'windows-latest'
   - name: linux_image
-    value: 'ubuntu-22.04'
+    value: 'ubuntu-24.04'
 
 stages:
 - stage: build_binaries

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -33,17 +33,17 @@ parameters:
     displayName: 'Python Version'
     type: string
     default: '3.11'
-  
+
 variables:
   - name: windows_image
     value: 'windows-latest'
   - name: linux_image
     value: 'ubuntu-22.04'
- 
+
 stages:
 - stage: build_binaries
   displayName: 'Build ${{ parameters.tool_name }} Artifact(s)'
-  
+
   jobs:
     - job: build_linux
       displayName: Build Linux Binaries
@@ -61,16 +61,16 @@ stages:
           env:
             REPO_URL: ${{ parameters.repo_url }}
             REPO_DIR: ${{ parameters.tool_name }}
-        
+
         - bash: |
             rustup update
             rustup target add aarch64-unknown-linux-gnu
             rustup target add x86_64-unknown-linux-gnu
           displayName: Setup Rust Targets
-        
+
         - bash: cargo install cross
           displayName: Install cross
-        
+
         - bash: |
             cross build --release --target aarch64-unknown-linux-gnu ${{ parameters.extra_build_args }}
           displayName: Build ${{ parameters.tool_name }} (Linux ARM64)
@@ -80,7 +80,7 @@ stages:
             cross build --release --target x86_64-unknown-linux-gnu ${{ parameters.extra_build_args }}
           displayName: Build ${{ parameters.tool_name }} (Linux X86_X64)
           workingDirectory: ${{ parameters.tool_name }}
-      
+
         - bash: |
             mkdir $(Build.ArtifactStagingDirectory)/Linux-ARM-64
             mkdir $(Build.ArtifactStagingDirectory)/Linux-x86-64
@@ -100,12 +100,12 @@ stages:
 
     - job: build_windows
       displayName: Build Windows Binaries
-      
+
       condition: eq('${{ parameters.upload_windows }}', 'true')
 
       pool:
         vmImage: ${{ variables.windows_image }}
-      
+
       steps:
       - checkout: none
       - bash: |
@@ -114,13 +114,13 @@ stages:
         env:
           REPO_URL: ${{ parameters.repo_url }}
           REPO_DIR: ${{ parameters.tool_name }}
-      
+
       - bash: |
           rustup update
           rustup target add x86_64-pc-windows-msvc
           rustup target add aarch64-pc-windows-msvc
         displayName: Setup Rust Targets
-      
+
       - bash: |
           cargo build --release --target aarch64-pc-windows-msvc ${{ parameters.extra_build_args }}
         displayName: Build ${{ parameters.tool_name }} (Windows-ARM64)
@@ -130,7 +130,7 @@ stages:
           cargo build --release --target x86_64-pc-windows-msvc ${{ parameters.extra_build_args }}
         displayName: Build ${{ parameters.tool_name }} (Windows-x86_X64)
         workingDirectory: ${{ parameters.tool_name }}
-      
+
       - pwsh: |
           New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/Windows-ARM-64"
           New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/Windows-x86-64"
@@ -148,7 +148,7 @@ stages:
 
     - job: publish
       displayName: Publish Binaries
-      
+
       dependsOn:
         - ${{ if eq(parameters.upload_linux, true) }}:
           - build_linux
@@ -157,7 +157,7 @@ stages:
 
       pool:
         vmImage: 'ubuntu-latest'
-      
+
       steps:
         - checkout: self
 
@@ -175,17 +175,17 @@ stages:
           inputs:
             artifactName: 'binaries'
             downloadPath: '$(Build.ArtifactStagingDirectory)'
-        
+
         - task: NuGetAuthenticate@1
           displayName: Authenticate Local Feed
-        
+
         - bash: |
             nuget-publish --Operation PackAndPush --OutputLog "$(Build.SourcesDirectory)/NugetLog.txt" --ConfigFilePath "$CONF_PATH" --InputFolderPath $(Build.ArtifactStagingDirectory) --Version ${{ parameters.tag }} --CustomLicensePath "$LICENSE"
           env:
             CONF_PATH: $(Build.SourcesDirectory)/.azurepipelines/nuget/${{ parameters.tool_name }}.yaml
             LICENSE: $(Build.SourcesDirectory)/.azurepipelines/nuget/license.txt
           displayName: Publish Nuget Package
-        
+
         - task: PublishBuildArtifacts@1
           displayName: 'Publish Artifact: NugetLog'
           inputs:

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -192,4 +192,3 @@ stages:
             PathtoPublish: '$(Build.SourcesDirectory)'
             ArtifactName: 'NugetLog.txt'
           condition: always()
-

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -1,0 +1,195 @@
+## @file
+# Azure Pipeline to build and publish cargo tools in a format supported by edk2-pytool-extension's external dependency.
+#
+# This template will clone the repository specified in the `repo_url` parameter at the tag specified in the `tag`
+# parameter and then build the tool for X64 and ARM64 for Windows and/or linux. These binaries will be published as a
+# nuget package in an internal format supported by edk2-pytool-extensions.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+parameters:
+  - name: tag
+    displayName: 'Cargo Make Version Tag'
+    type: string
+  - name: repo_url
+    displayName: 'Cargo Tool Repository URL'
+  - name: tool_name
+    displayName: 'Tool name (and nuget config file name)'
+    type: string
+  - name: extra_build_args
+    displayName: 'Extra build arguments'
+    type: string
+    default: ''
+  - name: upload_linux
+    displayName: 'Upload Linux Binaries (X64 and ARM64)'
+    type: boolean
+    default: true
+  - name: upload_windows
+    displayName: 'Upload Windows Binaries (X64 and ARM64)'
+    type: boolean
+    default: true
+  - name: python_version
+    displayName: 'Python Version'
+    type: string
+    default: '3.11'
+  
+variables:
+  - name: windows_image
+    value: 'windows-latest'
+  - name: linux_image
+    value: 'ubuntu-22.04'
+ 
+stages:
+- stage: build_binaries
+  displayName: 'Build ${{ parameters.tool_name }} Artifact(s)'
+  
+  jobs:
+    - job: build_linux
+      displayName: Build Linux Binaries
+
+      condition: eq('${{ parameters.upload_linux }}', 'true')
+
+      pool:
+        vmImage: ${{ variables.linux_image }}
+
+      steps:
+        - checkout: none
+        - bash: |
+            git clone --depth 1 --branch ${{ parameters.tag }} $REPO_URL $REPO_DIR
+          displayName: Checkout Repository
+          env:
+            REPO_URL: ${{ parameters.repo_url }}
+            REPO_DIR: ${{ parameters.tool_name }}
+        
+        - bash: |
+            rustup update
+            rustup target add aarch64-unknown-linux-gnu
+            rustup target add x86_64-unknown-linux-gnu
+          displayName: Setup Rust Targets
+        
+        - bash: cargo install cross
+          displayName: Install cross
+        
+        - bash: |
+            cross build --release --target aarch64-unknown-linux-gnu ${{ parameters.extra_build_args }}
+          displayName: Build ${{ parameters.tool_name }} (Linux ARM64)
+          workingDirectory: ${{ parameters.tool_name }}
+
+        - bash: |
+            cross build --release --target x86_64-unknown-linux-gnu ${{ parameters.extra_build_args }}
+          displayName: Build ${{ parameters.tool_name }} (Linux X86_X64)
+          workingDirectory: ${{ parameters.tool_name }}
+      
+        - bash: |
+            mkdir $(Build.ArtifactStagingDirectory)/Linux-ARM-64
+            mkdir $(Build.ArtifactStagingDirectory)/Linux-x86-64
+            chmod +x ${{ parameters.tool_name }}/target/aarch64-unknown-linux-gnu/release/$TOOL
+            chmod +x ${{ parameters.tool_name }}/target/x86_64-unknown-linux-gnu/release/$TOOL
+            cp ${{ parameters.tool_name }}/target/aarch64-unknown-linux-gnu/release/$TOOL $(Build.ArtifactStagingDirectory)/Linux-ARM-64
+            cp ${{ parameters.tool_name }}/target/x86_64-unknown-linux-gnu/release/$TOOL $(Build.ArtifactStagingDirectory)/Linux-x86-64
+          displayName: Copy Binaries
+          env:
+            TOOL: ${{ parameters.tool_name }}
+
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: binaries'
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            ArtifactName: 'binaries'
+
+    - job: build_windows
+      displayName: Build Windows Binaries
+      
+      condition: eq('${{ parameters.upload_windows }}', 'true')
+
+      pool:
+        vmImage: ${{ variables.windows_image }}
+      
+      steps:
+      - checkout: none
+      - bash: |
+          git clone --depth 1 --branch ${{ parameters.tag }} $REPO_URL $REPO_DIR
+        displayName: Checkout Repository
+        env:
+          REPO_URL: ${{ parameters.repo_url }}
+          REPO_DIR: ${{ parameters.tool_name }}
+      
+      - bash: |
+          rustup update
+          rustup target add x86_64-pc-windows-msvc
+          rustup target add aarch64-pc-windows-msvc
+        displayName: Setup Rust Targets
+      
+      - bash: |
+          cargo build --release --target aarch64-pc-windows-msvc ${{ parameters.extra_build_args }}
+        displayName: Build ${{ parameters.tool_name }} (Windows-ARM64)
+        workingDirectory: ${{ parameters.tool_name }}
+
+      - bash: |
+          cargo build --release --target x86_64-pc-windows-msvc ${{ parameters.extra_build_args }}
+        displayName: Build ${{ parameters.tool_name }} (Windows-x86_X64)
+        workingDirectory: ${{ parameters.tool_name }}
+      
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/Windows-ARM-64"
+          New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/Windows-x86-64"
+          Copy-Item ${{ parameters.tool_name }}/target/aarch64-pc-windows-msvc/release/$env:TOOL -Destination "$(Build.ArtifactStagingDirectory)/Windows-ARM-64"
+          Copy-Item ${{ parameters.tool_name }}/target/x86_64-pc-windows-msvc/release/$env:TOOL -Destination "$(Build.ArtifactStagingDirectory)/Windows-x86-64"
+        displayName: Copy Binaries
+        env:
+          TOOL: ${{ parameters.tool_name }}.exe
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: binaries'
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'binaries'
+
+    - job: publish
+      displayName: Publish Binaries
+      
+      dependsOn:
+        - ${{ if eq(parameters.upload_linux, true) }}:
+          - build_linux
+        - ${{ if eq(parameters.upload_windows, true) }}:
+          - build_windows
+
+      pool:
+        vmImage: 'ubuntu-latest'
+      
+      steps:
+        - checkout: self
+
+        - task: UsePythonVersion@0
+          displayName: 'Use Python ${{ parameters.python_version }}'
+          inputs:
+            versionSpec: '${{ parameters.python_version }}'
+
+        - bash: |
+            pip install --upgrade edk2-pytool-extensions
+          displayName: Install edk2-pytool-extensions
+
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download binaries artifact'
+          inputs:
+            artifactName: 'binaries'
+            downloadPath: '$(Build.ArtifactStagingDirectory)'
+        
+        - task: NuGetAuthenticate@1
+          displayName: Authenticate Local Feed
+        
+        - bash: |
+            nuget-publish --Operation PackAndPush --OutputLog "$(Build.SourcesDirectory)/NugetLog.txt" --ConfigFilePath "$CONF_PATH" --InputFolderPath $(Build.ArtifactStagingDirectory) --Version ${{ parameters.tag }}-rc2 --CustomLicensePath "$LICENSE"
+          env:
+            CONF_PATH: $(Build.SourcesDirectory)/.azurepipelines/nuget/${{ parameters.tool_name }}.yaml
+            LICENSE: $(Build.SourcesDirectory)/.azurepipelines/nuget/license.txt
+          displayName: Publish Nuget Package
+        
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: NugetLog'
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)'
+            ArtifactName: 'NugetLog.txt'
+          condition: always()
+

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -32,7 +32,7 @@ parameters:
   - name: python_version
     displayName: 'Python Version'
     type: string
-    default: '3.11'
+    default: '3.12'
 
 variables:
   - name: windows_image

--- a/.azurepipelines/templates/CargoToolRepublish.yml
+++ b/.azurepipelines/templates/CargoToolRepublish.yml
@@ -180,7 +180,7 @@ stages:
           displayName: Authenticate Local Feed
         
         - bash: |
-            nuget-publish --Operation PackAndPush --OutputLog "$(Build.SourcesDirectory)/NugetLog.txt" --ConfigFilePath "$CONF_PATH" --InputFolderPath $(Build.ArtifactStagingDirectory) --Version ${{ parameters.tag }}-rc2 --CustomLicensePath "$LICENSE"
+            nuget-publish --Operation PackAndPush --OutputLog "$(Build.SourcesDirectory)/NugetLog.txt" --ConfigFilePath "$CONF_PATH" --InputFolderPath $(Build.ArtifactStagingDirectory) --Version ${{ parameters.tag }} --CustomLicensePath "$LICENSE"
           env:
             CONF_PATH: $(Build.SourcesDirectory)/.azurepipelines/nuget/${{ parameters.tool_name }}.yaml
             LICENSE: $(Build.SourcesDirectory)/.azurepipelines/nuget/license.txt


### PR DESCRIPTION
Adds a template pipeline that compiles a specified cargo tool for the following target tripples:

1. x86_64-pc-windows-msvc (if `upload_windows == true`)
2. aarch64-pc-windows-msvc (if `upload_windows == true`)
3. x86_64-unknown-linux-gnu (if `upload_linux == true`)
4. aarch64-unknown-linux-gnu (if `upload_linux == true`)

The compiled binaries are formatted in an edk2-pytool-extension external dependency formatted layout.

Adds two consumers of the pipeline for cargo-make and cargo-tarpaulin