### PR TITLE
.sync/rust-toolchain.toml: Sync cargo-release

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -48,3 +48,4 @@
 {# Rust tool versions. #}
 {% set cargo_make = "0.37.24" %}
 {% set cargo_tarpaulin = "0.31.5" %}
+{% set cargo_release = "0.25.12" %}

--- a/.sync/rust_config/rust-toolchain.toml
+++ b/.sync/rust_config/rust-toolchain.toml
@@ -6,3 +6,4 @@ channel = "{{ sync_version.rust_toolchain }}"
 [tools]
 cargo-make = "{{ sync_version.cargo_make }}"
 cargo-tarpaulin = "{{ sync_version.cargo_tarpaulin }}"
+cargo-release = "{{ sync_version.cargo_release }}"


### PR DESCRIPTION
The release GitHub workflow downloads and caches the cargo tools in the rust-toolchain.toml file so sync it.