### PR TITLE
Add parameter in PrGete for Force upload binary and other artifacts

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -90,10 +90,18 @@ parameters:
   displayName: Binary Artifacts to Publish
   type: string
   default: ''
+- name: force_publish_binary_artifacts
+  displayName: Force Publish Binary Artifacts
+  type: boolean
+  default: false
 - name: artifacts_other
   displayName: Other Artifacts to Publish
   type: string
   default: ''
+- name: force_publish_other_artifacts
+  displayName: Force Publish Other Artifacts
+  type: boolean
+  default: false
 - name: os_type
   displayName: OS type on the self-hosted agent pools
   type: string
@@ -167,7 +175,9 @@ jobs:
       parameters:
         artifacts_identifier: '${{ item.Key }} ${{ item.Value.Targets }}'
         artifacts_binary: ${{ parameters.artifacts_binary }}
+        force_publish_binary_artifacts: ${{ parameters.force_publish_binary_artifacts }}
         artifacts_other: ${{ parameters.artifacts_other }}
+        force_publish_other_artifacts: ${{ parameters.force_publish_other_artifacts }}
         build_file: ${{ parameters.build_file }}
         build_pkgs: ${{ item.Value.Pkgs }}
         build_targets: ${{ item.Value.Targets }}

--- a/Steps/BinaryCopyAndPublish.yml
+++ b/Steps/BinaryCopyAndPublish.yml
@@ -19,6 +19,10 @@ parameters:
   displayName: Publish Artifacts
   type: boolean
   default: true
+- name: force_publish_binary_artifacts
+  displayName: Force Publish Binary Artifacts
+  type: boolean
+  default: false
 
 steps:
 - bash: |
@@ -28,6 +32,7 @@ steps:
     else
       echo "##vso[task.setvariable variable=artifacts_present]true"
     fi
+  condition: or(succeeded(), eq(${{ parameters.force_publish_binary_artifacts }}, 'true'))
 
 # Copy binaries to the artifact staging directory
 - task: CopyFiles@2

--- a/Steps/OtherCopyAndPublish.yml
+++ b/Steps/OtherCopyAndPublish.yml
@@ -19,6 +19,10 @@ parameters:
   displayName: Publish Artifacts
   type: boolean
   default: true
+- name: force_publish_other_artifacts
+  displayName: Force Publish Artifacts
+  type: boolean
+  default: false
 
 steps:
 - bash: |
@@ -28,6 +32,7 @@ steps:
     else
       echo "##vso[task.setvariable variable=artifacts_present]true"
     fi
+  condition: or(succeeded(), eq(${{ parameters.force_publish_other_artifacts }}, 'true'))
 
 # Copy other files to the artifact staging directory
 - task: CopyFiles@2

--- a/Steps/PrGate.yml
+++ b/Steps/PrGate.yml
@@ -12,6 +12,10 @@ parameters:
   displayName: Binary Artifacts to Publish
   type: string
   default: ''
+- name: force_publish_binary_artifacts
+  displayName: Force Publish Binary Artifacts
+  type: boolean
+  default: false
 - name: artifacts_identifier
   displayName: Artifacts Identifier
   type: string
@@ -20,6 +24,10 @@ parameters:
   displayName: Other Artifacts to Publish
   type: string
   default: ''
+- name: force_publish_other_artifacts
+  displayName: Force Publish Other Artifacts
+  type: boolean
+  default: false
 - name: build_archs
   displayName: Architectures (e.g. IA32, X64)
   type: string
@@ -233,6 +241,7 @@ steps:
     artifacts_binary: ${{ parameters.artifacts_binary }}
     artifacts_identifier: ${{ parameters.artifacts_identifier }}
     publish_artifacts: ${{ parameters.publish_artifacts }}
+    force_publish_binary_artifacts: ${{ parameters.force_publish_binary_artifacts }}
 
 # Copy other files to the artifact staging directory
 - template: OtherCopyAndPublish.yml
@@ -240,3 +249,4 @@ steps:
     artifacts_other: ${{ parameters.artifacts_other }}
     artifacts_identifier: ${{ parameters.artifacts_identifier }}
     publish_artifacts: ${{ parameters.publish_artifacts }}
+    force_publish_other_artifacts: ${{ parameters.force_publish_other_artifacts }}


### PR DESCRIPTION
Sometime we may want to force upload binary or other artifacts even previous build steps are failed, hence add `force_publish_binary_artifacts` and `force_publish_other_artifacts` parameters in `PrGete` to support this feature.

Default set to false to maintain the original behavior.