### PR TITLE
Always update artifacts_present variable in artifact publish

### DIFF
--- a/Steps/BinaryCopyAndPublish.yml
+++ b/Steps/BinaryCopyAndPublish.yml
@@ -28,6 +28,7 @@ steps:
     else
       echo "##vso[task.setvariable variable=artifacts_present]true"
     fi
+  condition: succeededOrFailed()
 
 # Copy binaries to the artifact staging directory
 - task: CopyFiles@2

--- a/Steps/OtherCopyAndPublish.yml
+++ b/Steps/OtherCopyAndPublish.yml
@@ -28,6 +28,7 @@ steps:
     else
       echo "##vso[task.setvariable variable=artifacts_present]true"
     fi
+  condition: succeededOrFailed()
 
 # Copy other files to the artifact staging directory
 - task: CopyFiles@2


### PR DESCRIPTION
The Binary and Other artifact publish is depending on `artifacts_present` variable, but the variable will only be set to false or true when all previous steps are success.

In some cases, we want to always upload the artifacts no matter previous steps are pass or failed, and this `artifacts_present` already be handled well to decide the binary and other artifact should be uploaded or not, hence add the `condition: succeededOrFailed()` to the step that set the `artifacts_present` variable