### PR TITLE
Synchronize files into `mu_feature_ffa` repo

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -44,6 +44,7 @@ group:
       microsoft/mu_tiano_plus
       microsoft/mu_feature_config
       microsoft/mu_oem_sample
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
 
@@ -72,6 +73,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample
@@ -132,6 +134,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -163,6 +166,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_uefi_variable
       microsoft/mu_oem_sample
@@ -183,6 +187,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -215,6 +220,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -242,6 +248,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -285,6 +292,7 @@ group:
     - source: .sync/github_templates/licensing/project_mu_and_tianocore_license.txt
       dest: License.txt
     repos: |
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_tiano_platforms
 
@@ -312,6 +320,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -341,6 +350,7 @@ group:
       microsoft/mu_crypto_release
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_dfci
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
@@ -436,6 +446,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_oem_sample
@@ -481,6 +492,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -509,6 +521,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -536,6 +549,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -582,6 +596,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -611,6 +626,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -677,6 +693,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable
@@ -726,6 +743,7 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_feature_uefi_variable

--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -446,7 +446,6 @@ group:
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
-      microsoft/mu_feature_ffa
       microsoft/mu_feature_ipmi
       microsoft/mu_feature_mm_supv
       microsoft/mu_oem_sample


### PR DESCRIPTION
This change onboards the `mu_feature_ffa` repo to be part of the mu repo collection, by synchronizing the necessary files into the repo automatically.