### PR TITLE
Update non-Default GitHub token usage to Mu GitHub app

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
@@ -40,7 +47,7 @@ jobs:
           CONFIG_PATH: .sync/Files.yml
           DRY_RUN: false
           FORK: false
-          GH_PAT: ${{ secrets.UEFI_BOT_REPO_FILE_SYNC }}
+          GH_PAT: ${{ steps.app-token.outputs.token }}
           GIT_EMAIL: uefibot@microsoft.com
           GIT_USERNAME: uefibot
           ORIGINAL_MESSAGE: true

--- a/.sync/workflows/leaf/backport-to-release-branch.yml
+++ b/.sync/workflows/leaf/backport-to-release-branch.yml
@@ -1,5 +1,12 @@
 # This workflow moves marked commits from a development branch to a release branch.
 #
+# This workflow requires a GitHub App with the following permissions:
+# - Read and write access to repository contents
+# - Read and write access to pull requests
+#
+# The GitHub App ID and private key should be stored in the repository as a variable named `MU_ACCESS_APP_ID` and a
+# secret named `MU_ACCESS_APP_PRIVATE_KEY` respectively.
+#
 # Each commit in the development branch is cherry-picked to the release branch if the commit originates from a merged
 # PR that is marked for backport.
 #
@@ -35,11 +42,18 @@ on:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.MU_ACCESS_APP_ID }}
+        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.CHERRY_PICK_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Determine Contribution Info
       id: backport_info
@@ -231,5 +245,5 @@ on:
         -H "Content-Type: application/json" \
         -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$PR_BRANCH\",\"base\":\"$BASE_BRANCH\",\"labels\":[\"type:release-merge-conflict\"]}"
       env:
-        CHERRY_PICK_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        CHERRY_PICK_TOKEN: ${{ steps.app-token.outputs.token }}
 {% endraw %}

--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -1,6 +1,13 @@
 # This workflow automatically creates a pull request for any submodule in the repo
 # that has a new GitHub release available. The release must follow semantic versioning.
 #
+# The GitHub App ID and private key should be stored in the repository as a variable named `MU_ACCESS_APP_ID` and a
+# secret named `MU_ACCESS_APP_PRIVATE_KEY` respectively.
+#
+# The GitHub App must grant the following permissions:
+# - Read and write access to repository contents
+# - Read and write access to pull requests
+#
 # NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
 #       instead of the file in this repo.
 #
@@ -30,10 +37,17 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
       - name: Update Submodules to Latest Release
         uses: microsoft/mu_devops/.github/actions/submodule-release-updater@{{ sync_version.mu_devops }}
         with:
-          GH_PAT: {% raw %}${{ secrets.SUBMODULE_UPDATER_TOKEN }}{% endraw %}
+          GH_PAT: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           GH_USER: "ProjectMuBot"
           GIT_EMAIL: "mubot@microsoft.com"
           GIT_NAME: "Project Mu Bot"


### PR DESCRIPTION
Generates tokens during workflow execution instead of directly depending on PATs.