### PR TITLE
FileSyncer.yml: Create app derived token for all repos

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
@@ -47,7 +48,7 @@ jobs:
           CONFIG_PATH: .sync/Files.yml
           DRY_RUN: false
           FORK: false
-          GH_PAT: ${{ steps.app-token.outputs.token }}
+          GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_EMAIL: uefibot@microsoft.com
           GIT_USERNAME: uefibot
           ORIGINAL_MESSAGE: true


### PR DESCRIPTION
Allow file syncer to access all repos in the owning repo's installation and use the `GH_INSTALLATION_TOKEN` parameter to provide the token as the action differentiates between PATs using `GH_PAT` and apps using `GH_INSTALLATION_TOKEN`.