### PR TITLE
Cherry Pick Workflow To Ensure Consistent Cherry-Picking

### DIFF
--- a/.github/Labels.yml
+++ b/.github/Labels.yml
@@ -41,6 +41,10 @@
   description: Requires integration attention
   color: 'a54418'
   aliases: []
+- name: impact:cherry-pick
+  description: Pull requests that are cherry-picked from another branch
+  color: 'f10f3c'
+  aliases: []
 - name: impact:non-functional
   description: Does not have a functional impact
   color: 'c2e0c6'

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,6 +1,6 @@
 # This workflow validates commit messages in a pull request to ensure they follow a specific pattern.
 # The pattern is defined as follows:
-# - The commit message must contain the string "[cherry-pick/XXX]" where XXX is a valid label.
+# - The commit message must contain the string "[cherry-pick]".
 # - The commit message must also contain "(cherry picked from commit <commit_hash>)" where <commit_hash> is a 40-character SHA-1 hash.
 # - Merge commits are ignored.
 #
@@ -20,7 +20,7 @@ on:
 
 jobs:
   cherry-pick-job:
-    if: contains(github.event.pull_request.title, '[cherry pick]') || contains(github.event.pull_request.title, '[cherry-pick]')
+    if: contains(github.event.pull_request.labels.*.name, 'cherry-pick')
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
 
         # Ensure the base branch is fetched
         git fetch origin $base_branch
-        
+
         # Get the commits included in the PR
         commits=$(git log --pretty=format:%H origin/$base_branch..HEAD)
 
@@ -49,7 +49,7 @@ jobs:
               continue
             fi
 
-            if [[ ! $(echo "$commit_message" | tr '[:upper:]' '[:lower:]') =~ \[cherry-pick\/.+\] ]] || [[ ! "$commit_message" =~ \(cherry\ picked\ from\ commit\ [0-9a-f]{40}\) ]]; then
+            if [[ ! $(echo "$commit_message" | tr '[:upper:]' '[:lower:]') =~ \[cherry-pick\] ]] || [[ ! "$commit_message" =~ \(cherry\ picked\ from\ commit\ [0-9a-f]{40}\) ]]; then
               echo "Commit $commit does not meet the required pattern."
               echo "Commit message: $commit_message"
               echo "Please use 'git cherry-pick -x <commit_hash>' to cherry-pick the commit."

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,62 @@
+# This workflow validates commit messages in a pull request to ensure they follow a specific pattern.
+# The pattern is defined as follows:
+# - The commit message must contain the string "[cherry-pick/XXX]" where XXX is a valid label.
+# - The commit message must also contain "(cherry picked from commit <commit_hash>)" where <commit_hash> is a 40-character SHA-1 hash.
+# - Merge commits are ignored.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: Cherry-Pick Workflow
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  cherry-pick-job:
+    if: contains(github.event.pull_request.title, '[cherry pick]') || contains(github.event.pull_request.title, '[cherry-pick]')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # Fetch the full history to ensure all commits are available
+
+    - name: Validate commit messages
+      run: |
+        base_branch="${{ github.event.pull_request.base.ref }}"
+
+        # Ensure the base branch is fetched
+        git fetch origin $base_branch
+        
+        # Get the commits included in the PR
+        commits=$(git log --pretty=format:%H origin/$base_branch..HEAD)
+
+        echo "Number of commits being reviewed: $(echo "$commits" | wc -w)"
+
+        for commit in $commits; do
+            commit_message=$(git log --format=%B -n 1 "$commit")
+
+            if [[ "$commit_message" =~ ^Merge ]]; then
+              echo "Warning: Commit $commit is a merge commit and will be ignored."
+              continue
+            fi
+
+            if [[ ! $(echo "$commit_message" | tr '[:upper:]' '[:lower:]') =~ \[cherry-pick\/.+\] ]] || [[ ! "$commit_message" =~ \(cherry\ picked\ from\ commit\ [0-9a-f]{40}\) ]]; then
+              echo "Commit $commit does not meet the required pattern."
+              echo "Commit message: $commit_message"
+              echo "Please use 'git cherry-pick -x <commit_hash>' to cherry-pick the commit."
+              exit 1
+            else
+              echo "Commit $commit meets the required pattern."
+            fi
+        done
+
+        echo "All commit messages meet the required pattern.";

--- a/.sync/github_templates/contributing/CONTRIBUTING.md
+++ b/.sync/github_templates/contributing/CONTRIBUTING.md
@@ -101,6 +101,8 @@ Project Mu pull requests autopopulate a PR description from a template in most r
        outside direct code modifications (and comments)?
      * Examples: Update readme file, add feature readme file, link to documentation
       on an a separate Web page, ...
+   * [] **Cherry Pick?**
+     * **Cherry Pick** - Is this pull request cherry picking?
 
 4. **Replace** this text as instructed:
 

--- a/.sync/github_templates/pull_requests/pull_request_template.md
+++ b/.sync/github_templates/pull_requests/pull_request_template.md
@@ -9,6 +9,7 @@ For details on how to complete these options and their meaning refer to [CONTRIB
 - [ ] Breaking change?
 - [ ] Includes tests?
 - [ ] Includes documentation?
+- [ ] Cherry Pick?
 {% for additional_checkbox in additional_checkboxes %}
 - [ ] {{ additional_checkbox }}
 {% endfor %}

--- a/.sync/workflows/config/label-issues/regex-pull-requests.yml
+++ b/.sync/workflows/config/label-issues/regex-pull-requests.yml
@@ -24,7 +24,7 @@ labels:
   - label: type:backport
     type: "pull_request"
     authors: ["mu-automation[bot]"]
-    branch : "repo-sync/mu_devops/default"  
+    branch : "repo-sync/mu_devops/default"
     base-branch: "dev/20[0-9]{4}"
 
   - label: type:backport
@@ -52,3 +52,7 @@ labels:
   - label: impact:testing
     type: "pull_request"
     body: '\[\s*(x|X){1}\s*\]\s*Includes\s*tests\?'
+
+  - label: type:cherry-pick
+    type: "pull_request"
+    body: '\s*\[\s*(x|X){1}\s*\]\s*Cherry\s*Pick\?'


### PR DESCRIPTION
## Description

This workflow ensures that cherry-picks are consistent and retain the relevant history for integrations.

Any PR with [Cherry Pick] or [Cherry-Pick] will trigger this workflow

It will check the following:
 1. Cherry picks contain "[CHERRY-PICK/*] *"
 2. (cherry picked from commit <sha256>)

If it's a "Merge" commit the commit will be ignored. (Needed during PR)

If the commit violates one of these policies, then the PR gate will fail with the failing commit

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

https://github.com/Flickdm/mu_tiano_plus/pull/1

## Integration Instructions

N/A