### PR TITLE
Update docker image to build QEMU v10

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -192,7 +192,7 @@ RUN update-alternatives \
 FROM build AS test
 
 ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
-ARG QEMU_BRANCH="v9.0.0"
+ARG QEMU_BRANCH="v10.0.0"
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
         autoconf \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -190,7 +190,7 @@ RUN update-alternatives \
 FROM build AS test
 
 ARG QEMU_URL="https://gitlab.com/qemu-project/qemu.git"
-ARG QEMU_BRANCH="v9.0.0"
+ARG QEMU_BRANCH="v10.0.0"
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
         autoconf \


### PR DESCRIPTION
This change picks up QEMU v10 for docker images, which has a timer feature for AArch64 that is needed by hafnium build v2.13.