### PR TITLE
PullRequests.github-issues: Add mu-automation to bot list

### DIFF
--- a/Notebooks/PullRequests.github-issues
+++ b/Notebooks/PullRequests.github-issues
@@ -27,7 +27,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview -author:app/microsoft-github-policy-service -author:uefibot -author:ProjectMuBot"
+    "value": "$repos is:open type:pr -author:app/dependabot -author:app/dependabot-preview -author:app/microsoft-github-policy-service -author:mu-automation[bot] -author:uefibot -author:ProjectMuBot"
   },
   {
     "kind": 1,


### PR DESCRIPTION
Excludes `mu-automation[bot]` account PRs in the human list.