### PR TITLE
submbodule-release-updater.yml: End raw sections with `endraw`

### DIFF
--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -41,13 +41,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% raw %}
-          private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% raw %}
+          app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% endraw %}
 
       - name: Update Submodules to Latest Release
         uses: microsoft/mu_devops/.github/actions/submodule-release-updater@{{ sync_version.mu_devops }}
         with:
-          GH_PAT: {% raw %}${{ steps.app-token.outputs.token }}{% raw %}
+          GH_PAT: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
           GH_USER: "ProjectMuBot"
           GIT_EMAIL: "mubot@microsoft.com"
           GIT_NAME: "Project Mu Bot"


### PR DESCRIPTION
Corrects a replacement typo in 0480efb to use `%endraw%` to end the raw sections.