### PR TITLE
containers: Sync rust related versions from Version.njk

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -121,8 +121,7 @@ ENV RUSTUP_HOME="$HOME/.rustup"
 ENV PATH="$CARGO_HOME/bin:$PATH"
 
 # Install Rust/Cargo and extras (rust-src, rust fmt, cargo-make, cargo-tarpaulin)
-RUN VERSION_URL="https://raw.githubusercontent.com/microsoft/mu_devops/main/.sync/Version.njk" && \
-    RUST_VERSION=$(curl -s ${VERSION_URL} | grep -oP '(?<=rust_toolchain = ").*(?=")') && \
+RUN RUST_VERSION={% endraw %}{{ sync_version.rust_toolchain }}{% raw %} && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
     rustup component add rustfmt rust-src --toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu
 

--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -127,12 +127,12 @@ RUN RUST_VERSION={% endraw %}{{ sync_version.rust_toolchain }}{% raw %} && \
 
 RUN mkdir cargo_downloads && \
     cd cargo_downloads && \
-    TAG_NAME=$(curl -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | jq -r '.tag_name') && \
+    TAG_NAME={% endraw %}{{ sync_version.cargo_make }}{% raw %} && \
     DOWNLOAD_URL="https://github.com/sagiegurari/cargo-make/releases/download/$TAG_NAME/cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu.zip" && \
     curl -L -o cargo-make.zip "$DOWNLOAD_URL" && \
     unzip cargo-make.zip && \
     mv cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu/cargo-make $CARGO_HOME/bin/ && \
-    TAG_NAME=$(curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | jq -r '.tag_name') && \
+    TAG_NAME={% endraw %}{{ sync_version.cargo_tarpaulin }}{% raw %} && \
     DOWNLOAD_URL="https://github.com/xd009642/tarpaulin/releases/download/$TAG_NAME/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz" && \
     curl -L -o cargo-tarpaulin.tar.gz "$DOWNLOAD_URL" && \
     tar -xzvf cargo-tarpaulin.tar.gz && \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -118,8 +118,7 @@ ENV RUSTUP_HOME="$HOME/.rustup"
 ENV PATH="$CARGO_HOME/bin:$PATH"
 
 # Install Rust/Cargo and extras (rust-src, rust fmt, cargo-make, cargo-tarpaulin)
-RUN VERSION_URL="https://raw.githubusercontent.com/microsoft/mu_devops/main/.sync/Version.njk" && \
-    RUST_VERSION=$(curl -s ${VERSION_URL} | grep -oP '(?<=rust_toolchain = ").*(?=")') && \
+RUN RUST_VERSION={% endraw %}{{ sync_version.rust_toolchain }}{% raw %} && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
     rustup component add rustfmt rust-src --toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu
 

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -124,12 +124,12 @@ RUN RUST_VERSION={% endraw %}{{ sync_version.rust_toolchain }}{% raw %} && \
 
 RUN mkdir cargo_downloads && \
     cd cargo_downloads && \
-    TAG_NAME=$(curl -s https://api.github.com/repos/sagiegurari/cargo-make/releases/latest | jq -r '.tag_name') && \
+    TAG_NAME={% endraw %}{{ sync_version.cargo_make }}{% raw %} && \
     DOWNLOAD_URL="https://github.com/sagiegurari/cargo-make/releases/download/$TAG_NAME/cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu.zip" && \
     curl -L -o cargo-make.zip "$DOWNLOAD_URL" && \
     unzip cargo-make.zip && \
     mv cargo-make-v$TAG_NAME-x86_64-unknown-linux-gnu/cargo-make $CARGO_HOME/bin/ && \
-    TAG_NAME=$(curl -s https://api.github.com/repos/xd009642/tarpaulin/releases/latest | jq -r '.tag_name') && \
+    TAG_NAME={% endraw %}{{ sync_version.cargo_tarpaulin }}{% raw %} && \
     DOWNLOAD_URL="https://github.com/xd009642/tarpaulin/releases/download/$TAG_NAME/cargo-tarpaulin-x86_64-unknown-linux-gnu.tar.gz" && \
     curl -L -o cargo-tarpaulin.tar.gz "$DOWNLOAD_URL" && \
     tar -xzvf cargo-tarpaulin.tar.gz && \

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -337,12 +337,14 @@ Steps for Updating Rust Tool Chain
 Steps required to update the Rust tool chain in the Mu DevOps repo. The steps are as follows:
 
 1. Update rust_toolchain in .sync/Version.njk to the new version. PR and merge to main.
-2. Run Build Containers workflow to build a new linux container image (which will use updated .sync/Version.njk).
-3. Update linux_build_container in .sync/Version.njk with the new version. PR and merge to main.
-4. Create new mu_devops tag (GitHub release).
-5. Update mu_devops in .sync/Version.njk to the newly generated tag. PR and merge to main.
-6. Run Sync Mu DevOps Files to Mu Repos workflow to sync the new version to all Mu repos.
-7. Complete associated PRs in the Mu repos.
+2. Run Sync Mu DevOps Files to Mu Repos workflow to sync the new version into the Mu Devops.
+3. Merge the PR into Mu DevOps main branch.
+3. Run Build Containers workflow to build a new linux container image (which will use updated .sync/Version.njk).
+4. Update linux_build_container in .sync/Version.njk with the new version. PR and merge to main.
+5. Create new mu_devops tag (GitHub release).
+6. Update mu_devops in .sync/Version.njk to the newly generated tag. PR and merge to main.
+7. Run Sync Mu DevOps Files to Mu Repos workflow to sync the new version to all Mu repos.
+8. Complete associated PRs in the Mu repos.
 
 Links
 =====


### PR DESCRIPTION
Sync's the rust toolchain version and cargo_make / cargo_tarpaulin version from the Version.njk file instead of needing to be updated manually.