### PR TITLE
Use pull_request instead of pull_request_target trigger

### DIFF
--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -43,7 +43,7 @@ jobs:
           configuration-path: .github/workflows/label-issues/file-paths.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
 
       - name: Apply PR Labels Based on Policies
         uses: srvaroa/labeler@v1.13.0
@@ -53,4 +53,4 @@ jobs:
           fail_on_error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened

--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -23,7 +23,7 @@ on:
     types:
       - edited
       - opened
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened

--- a/.sync/workflows/leaf/pull-request-formatting-validator.yml
+++ b/.sync/workflows/leaf/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened


### PR DESCRIPTION
Use pull_request to not run workflow changes on PRs from forks.

---

Note: Tested on fork in this PR https://github.com/makubacki/mu_basecore/pull/99