### PR TITLE
Use the GitHub app token for writing

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -21,11 +21,6 @@ jobs:
     name: Repo File Sync
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: write
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -32,16 +32,20 @@ jobs:
     name: Label Based on Messages
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Apply Labels Based on PR File Paths
         uses: actions/labeler@v4.3.0
         with:
           configuration-path: .github/workflows/label-issues/file-paths.yml
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           sync-labels: true
         if: github.event_name == 'pull_request'
 
@@ -52,5 +56,5 @@ jobs:
           use_local_config: false
           fail_on_error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ReleaseDrafter.yml
+++ b/.github/workflows/ReleaseDrafter.yml
@@ -46,11 +46,15 @@ jobs:
     name: Update Release Draft
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Download Version Information
         id: download_ver_info
         shell: bash
@@ -87,7 +91,7 @@ jobs:
           # Note: Path is relative to .github/
           config-name: release-draft-config-n.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Draft Release for Current (${{ env.latest_mu_release_branch }}) Release Branch
         if: steps.update_draft_n.outcome == 'success'
         run: |
@@ -128,7 +132,7 @@ jobs:
             --notes-file "$release_body_path" \
             --draft
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Build a ${{ env.previous_mu_release_branch }} Draft
         if: ${{ startsWith(github.ref, env.previous_mu_dev_branch_full) }}
         id: update_draft_n_1
@@ -137,7 +141,7 @@ jobs:
           # Note: Path is relative to .github/
           config-name: release-draft-config-n-1.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Draft Release for N-1 (${{ env.previous_mu_release_branch }}) Release Branch
         if: steps.update_draft_n_1.outcome == 'success'
         run: |
@@ -178,7 +182,7 @@ jobs:
             --notes-file "$release_body_path" \
             --draft
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create the ${{ env.latest_mu_dev_branch }} Draft
         if: ${{ startsWith(github.ref, env.latest_mu_dev_branch_full) }}
         uses: release-drafter/release-drafter@v6.1.0
@@ -186,7 +190,7 @@ jobs:
           # Note: Path is relative to .github/
           config-name: release-draft-config-n-dev.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create the ${{ env.previous_mu_dev_branch }} Draft
         if: ${{ startsWith(github.ref, env.previous_mu_dev_branch_full) }}
         uses: release-drafter/release-drafter@v6.1.0
@@ -194,7 +198,7 @@ jobs:
           # Note: Path is relative to .github/
           config-name: release-draft-config-n-1-dev.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Build the New Release Draft
         if: ${{ !startsWith(github.ref, 'refs/heads/release') && !startsWith(github.ref, 'refs/heads/dev') }}
         id: update_draft_non_release
@@ -203,4 +207,4 @@ jobs:
           # Note: Path is relative to .github/
           config-name: release-draft-config.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/Stale.yml
+++ b/.github/workflows/Stale.yml
@@ -71,9 +71,6 @@ jobs:
   stale:
     name: Stale
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
 
     steps:
     - name: Check for Stale Items

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened
@@ -24,11 +24,15 @@ jobs:
   validate_pr:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='
             query($name: String!, $owner: String!, $pr_number: Int!) {
@@ -45,7 +49,7 @@ jobs:
           fi
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,9 +29,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v15.0.2
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -25,17 +25,21 @@ jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
 
-    permissions:
-      pull-requests: write
-      issues: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Prune Won't Fix Pull Requests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \
@@ -50,7 +54,7 @@ jobs:
 
       - name: Prune Won't Fix Issues
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \

--- a/.github/workflows/stale-leaf.yml
+++ b/.github/workflows/stale-leaf.yml
@@ -24,9 +24,4 @@ on:
 
 jobs:
   check:
-
-    permissions:
-      issues: write
-      pull-requests: write
-
     uses: microsoft/mu_devops/.github/workflows/Stale.yml@v15.0.2

--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -23,7 +23,7 @@ on:
     types:
       - edited
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened
@@ -33,9 +33,5 @@ on:
 
 jobs:
   apply:
-
-    permissions:
-      contents: read
-      pull-requests: write
-
     uses: microsoft/mu_devops/.github/workflows/Labeler.yml@{{ sync_version.mu_devops }}
+    secrets: inherit

--- a/.sync/workflows/leaf/pull-request-formatting-validator.yml
+++ b/.sync/workflows/leaf/pull-request-formatting-validator.yml
@@ -24,10 +24,6 @@ jobs:
   validate_pr:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='

--- a/.sync/workflows/leaf/release-draft.yml
+++ b/.sync/workflows/leaf/release-draft.yml
@@ -39,9 +39,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@{{ sync_version.mu_devops }}
     secrets: inherit

--- a/.sync/workflows/leaf/scheduled-maintenance.yml
+++ b/.sync/workflows/leaf/scheduled-maintenance.yml
@@ -25,17 +25,21 @@ jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
 
-    permissions:
-      pull-requests: write
-      issues: write
-
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Prune Won't Fix Pull Requests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \
@@ -50,7 +54,7 @@ jobs:
 
       - name: Prune Won't Fix Issues
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ env.REPOSITORY_NAME }}
         run: |
           gh api \

--- a/.sync/workflows/leaf/stale.yml
+++ b/.sync/workflows/leaf/stale.yml
@@ -27,8 +27,4 @@ on:
 jobs:
   check:
 
-    permissions:
-      issues: write
-      pull-requests: write
-
     uses: microsoft/mu_devops/.github/workflows/Stale.yml@{{ sync_version.mu_devops }}

--- a/.sync/workflows/leaf/submodule-release-update.yml
+++ b/.sync/workflows/leaf/submodule-release-update.yml
@@ -32,10 +32,6 @@ jobs:
     name: Check for Submodule Releases
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - name: Generate Token
         id: app-token


### PR DESCRIPTION
Remove uses of the default GitHub token with write permission and instead use the GitHub app derived token which has write access.

- Removes setting the default token to have write access.
- Uses `pull_request_target` for the pull request triggered workflow to allow the secrets to be passed to the action used to derive the GitHub app token.