### PR TITLE
codeql: Use app token for API requests [Rebase & FF]

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -34,7 +34,7 @@ on:
       - main
       - release/*
       - dev/*
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - release/*
@@ -165,38 +165,44 @@ jobs:
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
+      env:
+        AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         import os
         import requests
         import sys
         import time
 
-        def get_response_with_retries(url, retries=5, wait_time=10):
+        def get_response_with_retries(url, headers, retries=5, wait_time=10):
           for attempt in range(retries):
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             if response.status_code == 200:
               return response
-            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed. Retrying in {wait_time} seconds...")
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed ({response.status_code}). Retrying in {wait_time} seconds...")
             time.sleep(wait_time)
           return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
+        headers = {
+          "Authorization": f"Bearer {os.environ['AUTH_TOKEN']}",
+          "Accept": "application/vnd.github.v3+json"
+        }
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           build_release_id = response.json()["id"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make release ID! ({response.status_code})")
           sys.exit(1)
 
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make! ({response.status_code})")
           sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -208,12 +208,18 @@ jobs:
 
 {% raw %}
 
-    - name: Attempt to Load cargo-make From Cache
+    # Temporarily disable caching cargo-make as it stopped working in some repos recently
+    # and need to be investigated
+    # - name: Attempt to Load cargo-make From Cache
+    #   id: cargo_make_cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+    #     key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+
+    - name: Force cargo-make cache miss
       id: cargo_make_cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
-        key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+      run: echo "cache-hit=false" >> $GITHUB_OUTPUT
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -213,12 +213,18 @@ jobs:
 
 {% raw %}
 
-    - name: Attempt to Load cargo-make From Cache
+    # Temporarily disable caching cargo-make as it stopped working in some repos recently
+    # and need to be investigated
+    # - name: Attempt to Load cargo-make From Cache
+    #   id: cargo_make_cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
+    #     key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+
+    - name: Force cargo-make cache miss
       id: cargo_make_cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
-        key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
+      run: echo "cache-hit=false" >> $GITHUB_OUTPUT
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -33,7 +33,7 @@ on:
       - main
       - release/*
       - dev/*
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - release/*
@@ -167,41 +167,55 @@ jobs:
 
 {% endraw %}
 
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.MU_ACCESS_APP_ID }}
+        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
+      env:
+        AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         import os
         import requests
         import sys
         import time
 
-        def get_response_with_retries(url, retries=5, wait_time=10):
+        def get_response_with_retries(url, headers, retries=5, wait_time=10):
           for attempt in range(retries):
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             if response.status_code == 200:
               return response
-            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed. Retrying in {wait_time} seconds...")
+            print(f"::warning title=GitHub API Access Error!::Attempt {attempt + 1} failed ({response.status_code}). Retrying in {wait_time} seconds...")
             time.sleep(wait_time)
           return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{{ sync_version.cargo_make }}"
+        headers = {
+          "Authorization": f"Bearer {os.environ['AUTH_TOKEN']}",
+          "Accept": "application/vnd.github.v3+json"
+        }
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           build_release_id = response.json()["id"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make release ID!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make release ID! ({response.status_code})")
           sys.exit(1)
 
         api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/{build_release_id}"
 
-        response = get_response_with_retries(api_url)
+        response = get_response_with_retries(api_url, headers)
         if response.status_code == 200:
           latest_cargo_make_version = response.json()["tag_name"]
         else:
-          print("::error title=GitHub Release Error!::Failed to get cargo-make!")
+          print(f"::error title=GitHub Release Error!::Failed to get cargo-make! ({response.status_code})")
           sys.exit(1)
 
         cache_key = f'cargo-make-{latest_cargo_make_version}'


### PR DESCRIPTION
Two changes for the CodeQL workflows:

---

**codeql: Use app token for API requests**

Make authenticated requests to prevent relying on the GitHub
anonymous API limit from potentially causing requests to
fail.

---

**codeql: Always download cargo make**

Temporarily always download cargo make instead of using the workflow
cache as loading from the cache has failed recently in some repos
and a root cause needs to be found for that issue.

Tracked in https://github.com/microsoft/mu_devops/issues/459