### PR TITLE
codeql: Add raw markers for Nunjucks

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -162,11 +162,19 @@ jobs:
 
 {% endraw %}
 
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% endraw %}
+        private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% endraw %}
+        owner: {% raw %}${{ github.repository_owner }}{% endraw %}
+
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       env:
-        AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
+        AUTH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
       run: |
         import os
         import requests

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -171,15 +171,15 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ vars.MU_ACCESS_APP_ID }}
-        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
+        app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% endraw %}
+        private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% endraw %}
+        owner: {% raw %}${{ github.repository_owner }}{% endraw %}
 
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       env:
-        AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
+        AUTH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
       run: |
         import os
         import requests


### PR DESCRIPTION
Marks GitHub variables as raw sections to prevent Nunjucks from interfering with them during file sync.