### PR TITLE
codeql: Go back to pull_request

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -34,7 +34,7 @@ on:
       - main
       - release/*
       - dev/*
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release/*
@@ -47,6 +47,8 @@ jobs:
   gather_build_files:
     name: Gather Platform Build Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       platform_build_files: ${{ steps.generate_matrix.outputs.platform_build_files }}
 
@@ -162,19 +164,11 @@ jobs:
 
 {% endraw %}
 
-    - name: Generate Token
-      id: app-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% endraw %}
-        private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% endraw %}
-        owner: {% raw %}${{ github.repository_owner }}{% endraw %}
-
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       env:
-        AUTH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+        AUTH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
       run: |
         import os
         import requests

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -33,7 +33,7 @@ on:
       - main
       - release/*
       - dev/*
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release/*
@@ -46,6 +46,8 @@ jobs:
   gather_packages:
     name: Gather Repo Packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       packages: ${{ steps.generate_matrix.outputs.packages }}
 
@@ -167,19 +169,11 @@ jobs:
 
 {% endraw %}
 
-    - name: Generate Token
-      id: app-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: {% raw %}${{ vars.MU_ACCESS_APP_ID }}{% endraw %}
-        private-key: {% raw %}${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}{% endraw %}
-        owner: {% raw %}${{ github.repository_owner }}{% endraw %}
-
     - name: Get Cargo Tool Details
       id: get_cargo_tool_details
       shell: python
       env:
-        AUTH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+        AUTH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
       run: |
         import os
         import requests


### PR DESCRIPTION
b9c5931 moved to pull_request_target to use the GitHub app to derive auth tokens. This may not allow GitHub to have the propoer context for the changes in the PR. This goes back to pull_request. Since only read permission is needed for the token, this sets uses the default token to make authenticated API calls.