### PR TITLE
Add to the dependenabot ignore subrepos the TFA and HAF repos

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -87,6 +87,8 @@ updates:
       - dependency-name: "MU_BASECORE"
       - dependency-name: "Silicon/Arm/MU_TIANO"
       - dependency-name: "Silicon/Intel/MU_TIANO"
+      - dependency-name: "Silicon/Arm/HAF"
+      - dependency-name: "Silicon/Arm/TFA"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
mu_tiano_platforms added Silicon/Arm/TFA and Silicon/Arm/HAF as submodules.

Dependabot was creating PRs to update.

Add these repos to the ignore list for dependabot.