### PR TITLE
Update rustfmt to use local repo version instead of mu_devops version.

### DIFF
--- a/.sync/rust_config/rustfmt.toml
+++ b/.sync/rust_config/rustfmt.toml
@@ -5,7 +5,7 @@
 
 # Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
 
-edition = "2021"                 # This would normally be picked up from Cargo.toml if not specified here
+edition = "2024"                 # This would normally be picked up from Cargo.toml if not specified here
 enum_discrim_align_threshold = 8 # Vertically align enum discriminants
 force_explicit_abi = true        # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
 hard_tabs = false                # Always uses spaces for indentation and alignment

--- a/.sync/rust_config/rustfmt.toml
+++ b/.sync/rust_config/rustfmt.toml
@@ -5,7 +5,6 @@
 
 # Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
 
-edition = "2024"                 # This would normally be picked up from Cargo.toml if not specified here
 enum_discrim_align_threshold = 8 # Vertically align enum discriminants
 force_explicit_abi = true        # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
 hard_tabs = false                # Always uses spaces for indentation and alignment


### PR DESCRIPTION
Some downstream repos updated to 2024 rustfmt.

Update the synced version of rustfmt to remove specifying a format.  This way, the edition will use the repo's Cargo.toml.