### PR TITLE
Update actions/checkout from v4 to v5

### DIFF
--- a/.github/workflows/Build-Containers.yml
+++ b/.github/workflows/Build-Containers.yml
@@ -46,7 +46,7 @@ jobs:
       SUB_IMAGES: ${{ matrix.sub_images }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/CodeQl.yml
+++ b/.github/workflows/CodeQl.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate Token
         id: app-token

--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate Token
         id: app-token

--- a/.github/workflows/IssueTriager.yml
+++ b/.github/workflows/IssueTriager.yml
@@ -26,7 +26,7 @@ jobs:
         template: [ bug_report.yml, documentation_request.yml, feature_request.yml ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate Token
         id: app-token

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: ✅ Checkout Repository ✅
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🛠️ Download Rust Tools 🛠️
         uses: microsoft/mu_devops/.github/actions/rust-tool-cache@main

--- a/.sync/workflows/leaf/backport-to-release-branch.yml
+++ b/.sync/workflows/leaf/backport-to-release-branch.yml
@@ -51,7 +51,7 @@ on:
         private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ steps.app-token.outputs.token }}

--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
 {% endraw %}
 
@@ -140,7 +140,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
 {% endraw %}
 

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
 {% endraw %}
 
@@ -103,7 +103,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
 {% endraw %}
 

--- a/.sync/workflows/leaf/publish-release.yml
+++ b/.sync/workflows/leaf/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate Branch
         run: |


### PR DESCRIPTION
Update actions/checkout@v4 to actions/checkout@v5

This will take place of the dependabot updates that are scattered throughout the repos. 
