### PR TITLE
Adding missing components from docker images

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -46,12 +46,17 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
+        clang \
         curl \
+        device-tree-compiler \
         flex \
         git \
         gnupg \
         gnupg2 \
         lcov \
+        libssl-dev \
+        lld \
+        llvm \
         jq \
         m4 \
         make \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -46,12 +46,17 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
+        clang \
         curl \
+        device-tree-compiler \
         flex \
         git \
         gnupg \
         gnupg2 \
         lcov \
+        libssl-dev \
+        lld \
+        llvm \
         jq \
         m4 \
         make \


### PR DESCRIPTION
This change adds 5 main components to the docker image to support Hafnium building:

`clang, device-tree-compiler, libssl-dev, lld, llvm`

This is tested with `docker build`, then pulled down top of main in mu_tiano_platforms from the built docker, build and run QemuSbsaPkg successfully.
