### PR TITLE
Version.njk: Update Ubuntu-24 container to 71390ed

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202405" %}
 
 {# The version of the ubuntu-24-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:68fa63a" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:71390ed" %}
 
 {# The Python version to use. #}
 {% set python_version = "3.12" %}


### PR DESCRIPTION
Updates to the latest container build with the components included for the Hafnium build.