### PR TITLE
Update rust version to 1.89

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -43,7 +43,7 @@
 {% set python_version = "3.12" %}
 
 {# The Rust toolchain version to use. #}
-{% set rust_toolchain = "1.85.0" %}
+{% set rust_toolchain = "1.89.0" %}
 
 {# Rust tool versions. #}
 {% set cargo_make = "0.37.24" %}


### PR DESCRIPTION
Step 1 to fully update the rust version to 1.85 to 1.89 as defined in [ReadMe#steps-for-updating-rust-toolchain](https://github.com/microsoft/mu_devops/?tab=readme-ov-file#steps-for-updating-rust-tool-chain).