### PR TITLE
Update container to 737aacc

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -37,7 +37,7 @@
 {% set previous_mu_release_branch = "release/202405" %}
 
 {# The version of the ubuntu-24-build container to use. #}
-{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:71390ed" %}
+{% set linux_build_container = "ghcr.io/microsoft/mu_devops/ubuntu-24-build:737aacc" %}
 
 {# The Python version to use. #}
 {% set python_version = "3.12" %}


### PR DESCRIPTION
Step 4 to fully update the rust version to 1.85 to 1.89 as defined in
[ReadMe#steps-for-updating-rust-toolchain](https://github.com/microsoft/mu_devops/?tab=readme-ov-file#steps-for-updating-rust-tool-chain).