### PR TITLE
Update mu_devops version for pipelines

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v16.0.0" %}
+{% set mu_devops = "v17.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202502" %}


### PR DESCRIPTION
Step 7 to fully update the rust version to 1.85 to 1.89 as defined in

[ReadMe#steps-for-updating-rust-toolchain](https://github.com/microsoft/mu_devops/?tab=readme-ov-file#steps-for-updating-rust-tool-chain).