### PR TITLE
Change RustCargoSteps to run as part of extra_install_steps

### DIFF
--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -160,9 +160,6 @@ jobs:
     steps:
     - ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/RustSetupSteps.yml
-      - template: ../Steps/RustCargoSteps.yml
-        parameters:
-          checkout_self: true
     - ${{ if and(contains(parameters.tool_chain_tag, 'CLANGPDB'), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/SetupToolChainTagPreReqs.yml
     - ${{ parameters.extra_steps }}
@@ -184,7 +181,15 @@ jobs:
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
         extra_install_step: ${{ parameters.extra_install_step }}
-        extra_pre_build_steps: ${{ parameters.extra_pre_build_steps }}
+        ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
+          extra_pre_build_steps:
+          - ${{ each step in parameters.extra_pre_build_steps }}:
+            - ${{ step }}
+          - template: ../Steps/RustCargoSteps.yml
+            parameters:
+              checkout_self: true
+        ${{ else }}:
+          extra_pre_build_steps: ${{ parameters.extra_pre_build_steps }}
         extra_post_build_steps: ${{ parameters.extra_post_build_steps }}
         # This is to handle the matrices that do not specify this.
         ${{ if eq(item.Value.SelfHostAgent, true) }}:

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -160,6 +160,9 @@ jobs:
     steps:
     - ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/RustSetupSteps.yml
+      - template: ../Steps/RustCargoSteps.yml
+        parameters:
+          checkout_self: true
     - ${{ if and(contains(parameters.tool_chain_tag, 'CLANGPDB'), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/SetupToolChainTagPreReqs.yml
     - ${{ parameters.extra_steps }}
@@ -180,16 +183,16 @@ jobs:
         do_pr_eval: ${{ parameters.do_pr_eval }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
-        extra_install_step: ${{ parameters.extra_install_step }}
-        ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
-          extra_pre_build_steps:
-          - ${{ each step in parameters.extra_pre_build_steps }}:
+        ${{ if eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
+          extra_install_step:
+          - ${{ each step in parameters.extra_install_step }}:
             - ${{ step }}
           - template: ../Steps/RustCargoSteps.yml
             parameters:
               checkout_self: true
         ${{ else }}:
-          extra_pre_build_steps: ${{ parameters.extra_pre_build_steps }}
+          extra_install_step: ${{ parameters.extra_install_step }}
+        extra_pre_build_steps: ${{ parameters.extra_pre_build_steps }}
         extra_post_build_steps: ${{ parameters.extra_post_build_steps }}
         # This is to handle the matrices that do not specify this.
         ${{ if eq(item.Value.SelfHostAgent, true) }}:

--- a/Jobs/PrGate.yml
+++ b/Jobs/PrGate.yml
@@ -160,9 +160,6 @@ jobs:
     steps:
     - ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/RustSetupSteps.yml
-      - template: ../Steps/RustCargoSteps.yml
-        parameters:
-          checkout_self: true
     - ${{ if and(contains(parameters.tool_chain_tag, 'CLANGPDB'), ne(item.Value.SelfHostAgent, true)) }}:
       - template: ../Steps/SetupToolChainTagPreReqs.yml
     - ${{ parameters.extra_steps }}
@@ -183,7 +180,7 @@ jobs:
         do_pr_eval: ${{ parameters.do_pr_eval }}
         tool_chain_tag: ${{ parameters.tool_chain_tag }}
         install_tools: ${{ and(not(eq(item.Value.SelfHostAgent, true)), not(parameters.container_build)) }}
-        ${{ if eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
+        ${{ if and(eq(parameters.rust_build, true), ne(item.Value.SelfHostAgent, true)) }}:
           extra_install_step:
           - ${{ each step in parameters.extra_install_step }}:
             - ${{ step }}


### PR DESCRIPTION
Move RustCargoSteps to be run as part of extra_install_steps so that submodues will be fully populated prior to attempting to execute code.

Encountered as part of https://github.com/microsoft/mu_tiano_platforms/pull/1207
RustCargoSteps were being run before the build sources were fully populated and it was resulting in platform build failures.

