### PR TITLE
Prevent dependabot from attempting to update Features/Ffa in mu_tiano_platforms

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -84,6 +84,7 @@ updates:
       - dependency-name: "Features/DFCI"
       - dependency-name: "Features/IPMI"
       - dependency-name: "Features/MM_SUPV"
+      - dependency-name: "Features/FFA"
       - dependency-name: "MU_BASECORE"
       - dependency-name: "Silicon/Arm/MU_TIANO"
       - dependency-name: "Silicon/Intel/MU_TIANO"


### PR DESCRIPTION
Add Feature/FFA to the list of submodules that dependabot should not attempt to update.

Feature/FFA should be handled though submodule updater.