### PR TITLE
Files.yml: Sync release-draft.yml as a template

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -578,6 +578,7 @@ group:
   - files:
     - source: .sync/workflows/leaf/release-draft.yml
       dest: .github/workflows/release-draft.yml
+      template: true
     - source: .sync/workflows/config/release-draft/release-draft-config.yml
       dest: .github/release-draft-config-n.yml
       template:


### PR DESCRIPTION
Previously a parameter was provided. Now, just set `template:true` to the file is treated as a template during syncing.

---

Small update that's needed for the file sync.