### PR TITLE
Version.njk: Update the Mu DevOps version to v18.0.0

### DIFF
--- a/.sync/Version.njk
+++ b/.sync/Version.njk
@@ -30,7 +30,7 @@
 #}
 
 {# The git ref value that files dependent on this repo will use. #}
-{% set mu_devops = "v17.0.1" %}
+{% set mu_devops = "v18.0.0" %}
 
 {# The latest Project Mu release branch value. #}
 {% set latest_mu_release_branch = "release/202502" %}


### PR DESCRIPTION
Updates Mu repos to use the latest Mu DevOps release.