### PR TITLE
CodeQL workflows: Remove dev branch trigger

### DIFF
--- a/.sync/workflows/leaf/codeql-platform.yml
+++ b/.sync/workflows/leaf/codeql-platform.yml
@@ -33,12 +33,10 @@ on:
     branches:
       - main
       - release/*
-      - dev/*
   pull_request:
     branches:
       - main
       - release/*
-      - dev/*
     paths-ignore:
       - '!**.c'
       - '!**.h'

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -32,12 +32,10 @@ on:
     branches:
       - main
       - release/*
-      - dev/*
   pull_request:
     branches:
       - main
       - release/*
-      - dev/*
     paths-ignore:
       - '!**.c'
       - '!**.h'


### PR DESCRIPTION
Does not trigger the workflow on the dev branch since the dev branch concept has been dropped from Project Mu.

---

One more reference found that is not needed.