### PR TITLE
[REBASE&FF] clangpdb-ci improvements

### DIFF
--- a/.sync/workflows/leaf/clangpdb-ci.yml
+++ b/.sync/workflows/leaf/clangpdb-ci.yml
@@ -27,6 +27,12 @@ on:
     branches:
       - {{ branch or sync_version.latest_mu_release_branch }}
 
+concurrency:
+{% raw %}
+  group: clangpdb-package-ci-${{ github.ref }}
+{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   package-matrix:
     name: Gather Repository Packages

--- a/.sync/workflows/leaf/clangpdb-ci.yml
+++ b/.sync/workflows/leaf/clangpdb-ci.yml
@@ -85,3 +85,26 @@ jobs:
 {% raw %}
       package-config: ${{ needs.package-matrix.outputs.matrix }}
 {% endraw %}
+
+  final:
+    name: Collapse Results
+{% raw %}
+    if: ${{ always() }}
+{% endraw %}
+    needs: [ubuntu-ci, windows-ci]
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check Matrix Jobs Results
+{% raw %}
+        run: |
+          echo "Ubuntu CI result: ${{ needs.ubuntu-ci.result }}"
+          echo "Windows CI result: ${{ needs.windows-ci.result }}"
+          
+          if [[ "${{ needs.ubuntu-ci.result }}" == "failure" || "${{ needs.windows-ci.result }}" == "failure" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          else
+            echo "All ubuntu and windows CI matrix jobs completed successfully"
+          fi
+{% endraw %}


### PR DESCRIPTION
This pull request does two things:

(1) It adds a concurrency group to the workflow so that when new pushes are made to a branch, any running CLANGPDB CI workflows running are cancelled

(2) It collapses all matrix job results into a single job that can be marked as `required` in the github UI for a PR to be merged. This is useful because some repositires have 10+ packages, resulting in over 40 jobs needing to be marked as required to pass.

## Testing

(1) Manually ran the file syncer to make sure the new changes sync properly across repositories
  - https://github.com/Javagedes/mu_devops/pull/4

(2) Ran the workflow in a repository, ensuring the final job passes are succeeds as expected
  - https://github.com/Javagedes/mu_basecore/actions/runs/24202010258
  - https://github.com/Javagedes/mu_basecore/actions/runs/24201048338