### PR TITLE
.sync: Add mm_supv clangpdb-ci

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -657,6 +657,7 @@ group:
     repos: |
       microsoft/mu_feature_config
       microsoft/mu_feature_dfci
+      microsoft/mu_feature_mm_supv
 
 # Leaf Workflow - CLANGPDB Package CI (mu_feature_ipmi and mu_feature_debugger)
   - files:


### PR DESCRIPTION
Adds `microsoft/mu_feature_mm_supv` to the list of repositories to have the `clangpdb-ci.yml` repo sync'd to.

It is added with the following configuration:

psuh / pull_request target branch: main
setup: both (stuart_ci_setup && stuart_setup)