### PR TITLE
PackageCi: Enable core.longpaths on Windows runners

### DIFF
--- a/.github/workflows/PackageCi.yml
+++ b/.github/workflows/PackageCi.yml
@@ -86,6 +86,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Enable Git Long Paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Python ${{ inputs.python-version }}
         if: ${{ inputs.container == null }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
Add git config --system core.longpaths true after checkout on Windows runners to prevent failures when submodule trees contain filenames exceeding the 260-character Windows path limit.

Without this MU_CRYPTO_RELEASE is failing

https://github.com/microsoft/mu_crypto_release/actions/runs/25198194771/job/73883433904?pr=218

```
Cloning into 'D:/a/mu_crypto_release/mu_crypto_release/MU_BASECORE/SecurityPkg/DeviceSecurity/SpdmLib/libspdm/os_stub/openssllib/openssl/gost-engine/libprov'...
error: unable to create file 
....
```