### PR TITLE
Add mu_crypto_release to CodeQL workflow sync

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -345,6 +345,7 @@ group:
     repos: |
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
+      microsoft/mu_crypto_release
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci


### PR DESCRIPTION
Add microsoft/mu_crypto_release to the leaf CodeQL CI workflow sync list so the repo receives the codeql.yml workflow and gets CodeQL security scanning on push and PR.