### PR TITLE
.sync: Add arch sync param to the CodeQL workflow

### DIFF
--- a/.sync/Files.yml
+++ b/.sync/Files.yml
@@ -338,14 +338,15 @@ group:
 # Leaf Workflow - CodeQL
 # Note: This workflow should be used in repos that build firmware
 #       packages from a CI builder (i.e. a CISettings.py file).
+# IA32 & X64 architectures
   - files:
     - source: .sync/workflows/leaf/codeql.yml
       dest: .github/workflows/codeql.yml
-      template: true
+      template:
+        archs: IA32,X64
     repos: |
       microsoft/mu_basecore
       microsoft/mu_common_intel_min_platform
-      microsoft/mu_crypto_release
       microsoft/mu_feature_config
       microsoft/mu_feature_debugger
       microsoft/mu_feature_dfci
@@ -353,6 +354,15 @@ group:
       microsoft/mu_feature_mm_supv
       microsoft/mu_oem_sample
       microsoft/mu_plus
+
+# X64 architecture only
+  - files:
+    - source: .sync/workflows/leaf/codeql.yml
+      dest: .github/workflows/codeql.yml
+      template:
+        archs: X64
+    repos: |
+      microsoft/mu_crypto_release
 
 # Leaf Workflow - CodeQL - Platform
 # Note: This workflow should be used in repos that build firmware

--- a/.sync/workflows/leaf/codeql.yml
+++ b/.sync/workflows/leaf/codeql.yml
@@ -72,10 +72,11 @@ jobs:
 
         packages = [d for d in os.listdir() if d.strip().lower().endswith('pkg')]
 
-        # Ensure the package can actually be built for IA32 or X64
+        # Ensure the package can actually be built for the target architectures
+        archs = [a.strip() for a in '{% endraw %}{{ archs }}{% raw %}'.split(',')]
         for package in list(packages):
             dsc = [os.path.join(package, f) for f in os.listdir(package) if f.endswith('.dsc')]
-            if not any('IA32' in l or 'X64' in l for d in dsc for l in open(d) if 'SUPPORTED_ARCHITECTURES' in l):
+            if not any(arch in l for d in dsc for l in open(d) if 'SUPPORTED_ARCHITECTURES' in l for arch in archs):
                 packages.remove(package)
 
         packages.sort()
@@ -100,7 +101,8 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.gather_packages.outputs.packages) }}
         include:
-          - archs: IA32,X64
+          - archs: {% endraw %}{{ archs }}{% raw %}
+
           - tool_chain_tag: VS2022
 
     steps:


### PR DESCRIPTION
Allow the architecture list to be passed into the workflow for matrix generation. All existing repos continue to use the previous default of "IA32,X64", the mu_crypto_release repo only supports X64, so sync it accordingly.

---

Note: Bug label applied since this addresses a CodeQL build failure introduced in 2ffad0f6cdc571ebac816ae29853f7ecdec76731.