### PR TITLE
Containers: Add gcc-multilib for IA32 cross-compilation support

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        gcc-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
         gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
         gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \

--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update && \
         gnupg2 \
         lcov \
         libssl-dev \
+        libxml-parser-perl \
+        libxml-simple-perl \
         lld \
         llvm \
         jq \
@@ -77,6 +79,7 @@ RUN apt-get update && \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        g++-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
         gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update && \
         gnupg2 \
         lcov \
         libssl-dev \
+        libxml-parser-perl \
+        libxml-simple-perl \
         lld \
         llvm \
         jq \
@@ -74,6 +76,7 @@ RUN apt-get update && \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        g++-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
         gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update && \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
+        gcc-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
         gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
         gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \


### PR DESCRIPTION
## Description

The Ubuntu-22 and Ubuntu-24 build container templates (.sync/containers/) are missing several packages required for IA32 cross-compilation and AGESA firmware builds.

## Problem

1. **IA32 builds fail** with atal error: bits/libc-header-start.h: No such file or directory
   - GCC uses the -m32 flag for IA32 targets (defined in BaseTools/Conf/tools_def.template)
   - This requires 32-bit glibc development headers provided by gcc-multilib / g++-multilib

2. **AGESA CBS builds fail** with atal error: IdsNvIdWH.h: No such file or directory
   - AGESA's AmdCbsPkg/Tools/IdsIdGen.pl uses XML::Simple and XML::Parser to generate header files at build time
   - These Perl modules are provided by libxml-simple-perl and libxml-parser-perl

## Root Cause

The container images already install cross-compilation toolchains for ARM, AArch64, and RISC-V architectures, but lack:
- The 32-bit x86 multilib packages (on x86_64 hosts, IA32 compilation uses native GCC with -m32 rather than a cross-compiler)
- Perl XML modules needed by AGESA code-generation scripts

## Changes

Added to .sync/containers/Ubuntu-22/Dockerfile and .sync/containers/Ubuntu-24/Dockerfile:

- **gcc-multilib** - 32-bit glibc headers/libs for IA32 builds
- **g++-multilib** - 32-bit C++ support (tianocore container parity)
- **libxml-parser-perl** - XML::Parser module for AGESA IdsIdGen.pl
- **libxml-simple-perl** - XML::Simple module for AGESA IdsIdGen.pl

## Testing

Validated against a Project MU AMD platform build targeting IA32+X64 architectures with TOOL_CHAIN_TAG=GCC. Without these packages:
- Build fails at IA32 compilation (missing 32-bit headers)
- Build fails at CBS library compilation (missing generated headers from Perl scripts)
