### PR TITLE
Containers: Revert Ubuntu-22 multilib and Perl XML additions

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -55,8 +55,6 @@ RUN apt-get update && \
         gnupg2 \
         lcov \
         libssl-dev \
-        libxml-parser-perl \
-        libxml-simple-perl \
         lld \
         llvm \
         jq \
@@ -79,8 +77,6 @@ RUN apt-get update && \
         {% endraw %}python{{ sync_version.python_version }}{% raw %} \
         {% endraw %}python{{ sync_version.python_version }}{% raw %}-venv \
         g++-${GCC_MAJOR_VERSION} gcc-${GCC_MAJOR_VERSION} \
-        g++-${GCC_MAJOR_VERSION}-multilib \
-        gcc-${GCC_MAJOR_VERSION}-multilib \
         gcc-${GCC_MAJOR_VERSION}-x86-64-linux-gnux32 \
         gcc-${GCC_MAJOR_VERSION}-aarch64-linux-gnu \
         gcc-${GCC_MAJOR_VERSION}-riscv64-linux-gnu \


### PR DESCRIPTION
## Description

Reverts the Ubuntu-22 Dockerfile changes from #572. These packages (gcc-multilib, g++-multilib, libxml-parser-perl, libxml-simple-perl) are only needed for the Ubuntu-24 container image.

**Why revert Ubuntu-22:**
- No known consumer uses Ubuntu-22 for IA32 cross-compilation
- The multilib packages conflict with \gcc-12-x86-64-linux-gnux32\ causing a failure with exit code 100
- The Perl XML modules were added for AGESA CBS header generation which only runs in the Ubuntu-24 pipeline

## Changes

- Removes \libxml-parser-perl\ and \libxml-simple-perl\ from Ubuntu-22 Dockerfile template
- Removes \g++-\-multilib\ and \gcc-\-multilib\ from Ubuntu-22 Dockerfile template

## Testing

Ubuntu-24 container is unaffected (retains all additions from #572).