### PR TITLE
Update NodeTool to UseNode

### DIFF
--- a/Steps/SetNodeVersion.yml
+++ b/Steps/SetNodeVersion.yml
@@ -7,7 +7,7 @@
 
 steps:
 
-- task: NodeTool@0
+- task: UseNode@1
   inputs:
-    versionSpec: '19.x'
+    version: '24.x'
   condition: succeeded()


### PR DESCRIPTION
NodeTool has been depreciated:
https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/node-tool-v0?view=azure-pipelines

Update to UseNode@1 and update syntax.

Update to version 24.x to address pipeline warning messages. 