### PR TITLE
Handle “no new commits” scenario in GenerateTag template as a successful no‑op

### DIFF
--- a/Jobs/GenerateTag.yml
+++ b/Jobs/GenerateTag.yml
@@ -75,6 +75,16 @@ jobs:
         displayName: "Run Tag Generator"
         workingDirectory: $(Agent.BuildDirectory)
 
+      - bash: |
+          echo "Generated tag: '$(tag_name)'"
+          if [ -z "$(tag_name)" ]; then
+          echo "No new commits since last tag."
+            echo "##vso[task.setvariable variable=skip_tag_generation]true"
+          else
+            echo "##vso[task.setvariable variable=skip_tag_generation]false"
+          fi
+        displayName: Detect no-op tag generation
+        
       - script: |
           set -e
           git branch
@@ -86,3 +96,4 @@ jobs:
         continueOnError: false
         displayName: "Create Tag"
         workingDirectory: $(Agent.BuildDirectory)/target
+        condition: ne(variables.skip_tag_generation, 'true')


### PR DESCRIPTION
### Summary

Handle the “no new commits since last tag” scenario in `GenerateTag.yml` as a successful no‑op instead of failing the pipeline.

### Problem

When no new commits exist:

- `TagGenerator.py` exits successfully but does not set `tag_name`
- Pipeline still attempts to create/push a tag
- Results in failure (tag_name: command not found)

  
<img width="927" height="1067" alt="Failure_No_Commit" src="https://github.com/user-attachments/assets/98fab9ad-8d66-469a-b6f3-9dc639254202" />


### Fix

- Detect absence of `tag_name` after `TagGenerator` execution
- Introduce `skip_tag_generation` flag
- Skip tag/commit/push steps when no tag is generated
- Add a no‑op completion message

### Result

- Pipeline succeeds when there are no changes, it has been tested in ADO.
- Tag is created only when needed
- No masking of real failures


<img width="1306" height="561" alt="Successful_run" src="https://github.com/user-attachments/assets/8831ba17-9c8f-42a0-8e20-c8d8e94fe90b" />
