### PR TITLE
Update --timings arg for Cargo 1.94+

### DIFF
--- a/.sync/rust_config/Makefile.toml
+++ b/.sync/rust_config/Makefile.toml
@@ -8,7 +8,7 @@ ARCH = "X64"
 TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
 
 CARGO_FEATURES_FLAG = {value = "--features ${FEATURES}", condition = {env_set = ["FEATURES"], env_true = ["FEATURES"]}}
-BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
+BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --timings"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--out html --out xml --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
 


### PR DESCRIPTION
Remove the unstable arg `--timings=html`, which is no longer supported from Cargo 1.94. (see https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-194-2026-03-05)

Instead, use the stable `--timings` (stable since 1.60 https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-160-2022-04-07) to generate the html report.

Tested a UEFI build with rust toolchains 1.92, 1.93, and 1.95 using the modified flags in mu_plus Makefile.toml, build successful in all cases.

Resolves #585 