### PR TITLE
Decrease Update Frequency [Rebase & FF]

### DIFF
--- a/.github/workflows/FileSyncer.yml
+++ b/.github/workflows/FileSyncer.yml
@@ -12,8 +12,8 @@ name: Sync Mu DevOps Files to Mu Repos
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run daily at 9am UTC - https://crontab.guru/#0_9_*_*_*
-    - cron: '0 9 * * *'
+    # Run weekly on Tuesday at 14:00 UTC - https://crontab.guru/#0_14_*_*_2
+    - cron: '0 14 * * 2'
   workflow_dispatch:
 
 jobs:

--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "03:00"
@@ -49,7 +49,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
@@ -71,7 +71,7 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "tuesday"
       timezone: "America/Los_Angeles"
       time: "23:00"
@@ -104,7 +104,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "03:00"
@@ -44,7 +44,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
@@ -66,7 +66,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"


### PR DESCRIPTION
These two commits are intended to reduce the amount of overall effort spent to integrate updates across a large number of Mu repos while still ensuring updates happen on a regular schedule.

---

**.sync: Move dependabot updates to monthly**

Given each dependabot update requires two human reviews in over 20
repos, a single dependency can trigger a large amount of CI resource
usage and human distraction.

This change moves the dependabot updates to monthly which still allows
updates to be picked up a frequent basis while reducing the amount of
overhead.

---

**.github: Trigger file syncer weekly instead of daily**

File syncs can be triggered manually when needed. The timer is more
of a safety net to ensure that the syncer does not accumulate too many
changes before it is run.

This changes the schedule to run weekly on Tuesday at 14:00 UTC
instead of daily at 9am UTC.