### PR TITLE
Dependabot: Add 7 day cooldown period to dependabot updates.

### DIFF
--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -34,6 +34,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "03:00"
+    cooldown:
+      days: 7
     commit-message:
       prefix: "Rust Dependency"
     labels:
@@ -48,6 +50,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
+    cooldown:
+      days: 7
     ignore:
       # Ignore dependencies that are synced from mu_devops
       - dependency-name: "microsoft/mu_devops*"
@@ -70,6 +74,8 @@ updates:
       day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"
+    cooldown:
+      days: 7
     groups:
       all-pip-dependencies:
         patterns:


### PR DESCRIPTION
This is to improve supply chain security by giving a seven day
buffer for malicious dependencies to be reported before
Mu repos/platform adopt the dependency.