### PR TITLE
.sync: Fix dependabot cooldown days

### DIFF
--- a/.sync/dependabot/actions-pip-submodules.yml
+++ b/.sync/dependabot/actions-pip-submodules.yml
@@ -39,6 +39,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "03:00"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "Rust Dependency"
     labels:
@@ -53,6 +55,8 @@ updates:
       day: "monday"
       timezone: "America/Los_Angeles"
       time: "06:00"
+    cooldown:
+      default-days: 7
     ignore:
       # Ignore dependencies that are synced from mu_devops
       - dependency-name: "microsoft/mu_devops*"
@@ -108,6 +112,8 @@ updates:
       day: "wednesday"
       timezone: "America/Los_Angeles"
       time: "01:00"
+    cooldown:
+      default-days: 7
     groups:
       all-pip-dependencies:
         patterns:

--- a/.sync/dependabot/actions-pip.yml
+++ b/.sync/dependabot/actions-pip.yml
@@ -35,7 +35,7 @@ updates:
       timezone: "America/Los_Angeles"
       time: "03:00"
     cooldown:
-      days: 7
+      default-days: 7
     commit-message:
       prefix: "Rust Dependency"
     labels:
@@ -51,7 +51,7 @@ updates:
       timezone: "America/Los_Angeles"
       time: "06:00"
     cooldown:
-      days: 7
+      default-days: 7
     ignore:
       # Ignore dependencies that are synced from mu_devops
       - dependency-name: "microsoft/mu_devops*"
@@ -75,7 +75,7 @@ updates:
       timezone: "America/Los_Angeles"
       time: "01:00"
     cooldown:
-      days: 7
+      default-days: 7
     groups:
       all-pip-dependencies:
         patterns:


### PR DESCRIPTION
The current `days` key is invalid as reported by dependabot validation:

```
The property '#/updates/0/cooldown' contains additional properties
  ["days"] outside of the schema when none are allowed
The property '#/updates/1/cooldown' contains additional properties
  ["days"] outside of the schema when none are allowed
The property '#/updates/2/cooldown' contains additional properties
  ["days"] outside of the schema when none are allowed
```

This change updates the key to `default-days` per:

https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-