### PR TITLE
Containers: Install 32-bit development packages for IA32 host tests

### DIFF
--- a/.sync/containers/Ubuntu-22/Dockerfile
+++ b/.sync/containers/Ubuntu-22/Dockerfile
@@ -42,7 +42,8 @@ ENV TZ=UTC
 # the .local/bin directory to the path which will be used by pip.
 ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
 
-RUN apt-get update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
@@ -68,6 +69,9 @@ RUN apt-get update && \
         unzip \
         uuid-dev \
         wget \
+        libc6-i386 \
+        libc6-dev-i386 \
+        linux-libc-dev:i386 \
         && \
     apt-get update && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F23C5A6CF475977595C89F51BA6932366A755776 && \

--- a/.sync/containers/Ubuntu-24/Dockerfile
+++ b/.sync/containers/Ubuntu-24/Dockerfile
@@ -42,7 +42,8 @@ ENV TZ=UTC
 # the .local/bin directory to the path which will be used by pip.
 ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
 
-RUN apt-get update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
@@ -70,6 +71,9 @@ RUN apt-get update && \
         unzip \
         uuid-dev \
         wget \
+        libc6-i386 \
+        libc6-dev-i386 \
+        linux-libc-dev:i386 \
         && \
     apt-get update && \
     apt-get install --yes --no-install-recommends \

--- a/Containers/Ubuntu-22/Dockerfile
+++ b/Containers/Ubuntu-22/Dockerfile
@@ -39,7 +39,8 @@ ENV TZ=UTC
 # the .local/bin directory to the path which will be used by pip.
 ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
 
-RUN apt-get update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
@@ -65,6 +66,9 @@ RUN apt-get update && \
         unzip \
         uuid-dev \
         wget \
+        libc6-i386 \
+        libc6-dev-i386 \
+        linux-libc-dev:i386 \
         && \
     apt-get update && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F23C5A6CF475977595C89F51BA6932366A755776 && \

--- a/Containers/Ubuntu-24/Dockerfile
+++ b/Containers/Ubuntu-24/Dockerfile
@@ -39,7 +39,8 @@ ENV TZ=UTC
 # the .local/bin directory to the path which will be used by pip.
 ENV PATH $PATH:/home/vsts_azpcontainer/.local/bin
 
-RUN apt-get update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends \
         bison \
         ca-certificates \
@@ -67,6 +68,9 @@ RUN apt-get update && \
         unzip \
         uuid-dev \
         wget \
+        libc6-i386 \
+        libc6-dev-i386 \
+        linux-libc-dev:i386 \
         && \
     apt-get update && \
     apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
Add the 32-bit libc development packages to the Ubuntu build containers.

The Host Unit Test Compiler Plugin builds IA32 applications with -m32.
Without the 32 bit development headers, C++ standard library includes
eventually fail in linux/errno.h because asm/errno.h cannot be found.

Installing these packages provides the required IA32 headers, runtime
libraries, startup objects, and compiler support.



Created local docker image for ubuntu-24 and verified that IA32 GCC NOOPT builds completed successfully.